### PR TITLE
Add word list resource for name generator

### DIFF
--- a/name_generator/resources/WordListResource.gd
+++ b/name_generator/resources/WordListResource.gd
@@ -1,0 +1,22 @@
+@tool
+extends Resource
+class_name WordListResource
+
+## WordListResource provides simple and weighted word collections for the name generator.
+## Designers can configure either `entries` for equal-probability names or `weighted_entries`
+## for fine-grained control over selection probability.
+
+## Simple list of entries used when each name should have equal probability of being chosen.
+## Populate this when weighting is not required. Leave empty when using `weighted_entries`.
+@export_placeholder("Example: Alice, Bob, Carol")
+@export var entries: PackedStringArray = PackedStringArray()
+
+## Weighted entries allow assigning relative selection weights to each value.
+## Each dictionary entry should contain a `value` (String) and a `weight` (float > 0).
+## Use this list instead of `entries` when specific probability distribution is needed.
+@export_placeholder('Example: [{"value": "Alice", "weight": 1.0}]')
+@export var weighted_entries: Array[Dictionary] = []
+
+## Utility method to determine if any weighted data has been provided.
+func has_weighted_entries() -> bool:
+    return not weighted_entries.is_empty()

--- a/project.godot
+++ b/project.godot
@@ -5,11 +5,15 @@
 ; Format:
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
-
 config_version=5
 
 [application]
-
 config/name="New Game Project"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+
+[global_script_classes]
+global_script_classes=[{ "base": "Resource", "class": "WordListResource", "language": "GDScript", "path": "res://name_generator/resources/WordListResource.gd" }]
+
+[global_script_class_icons]
+WordListResource=""


### PR DESCRIPTION
## Summary
- add a tool script resource for configuring simple and weighted word lists
- expose export hints to guide designers on how to populate entries
- register the resource globally so it can be created from the Godot editor

## Testing
- `godot4 --headless --run-tests` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caac1cef5483208f215e5f7281628f