### PR TITLE
Implement word list generator strategy

### DIFF
--- a/name_generator/resources/WordListResource.gd
+++ b/name_generator/resources/WordListResource.gd
@@ -1,0 +1,27 @@
+## Resource that encapsulates the list of candidate words a strategy can pick
+## from.  Each entry can optionally define a weight to bias the selection.
+##
+## The resource is intentionally lightweight so it can be easily authored in
+## the Godot inspector.  Designers can provide a PackedStringArray of entries
+## and, when weighted selection is desired, a parallel PackedFloat32Array.
+extends Resource
+class_name WordListResource
+
+## Textual candidates that can be combined into generated names.
+@export var entries: PackedStringArray = PackedStringArray()
+
+## Optional weights that map 1:1 to ``entries``.  When left empty, selection is
+## treated as uniform.
+@export var weights: PackedFloat32Array = PackedFloat32Array()
+
+## Returns a standard ``Array`` copy of the configured entries.  A copy is used
+## so callers can safely mutate the result without affecting the resource.
+func get_entries() -> Array:
+    return entries.to_array()
+
+## Returns a standard ``Array`` view of the configured weights when valid.
+## The method performs validation to ensure we never emit mismatched arrays.
+func get_weights() -> Array:
+    if weights.is_empty() or weights.size() != entries.size():
+        return []
+    return weights.to_array()

--- a/name_generator/strategies/GeneratorStrategy.gd
+++ b/name_generator/strategies/GeneratorStrategy.gd
@@ -1,0 +1,31 @@
+## Abstract base class for name generation strategies.
+##
+## Strategies consume a configuration dictionary and emit generated values.
+## They also expose a consistent error-reporting interface so the calling code
+## can surface actionable feedback to designers or telemetry systems.
+extends Resource
+class_name GeneratorStrategy
+
+## Emitted whenever the strategy cannot produce a result due to configuration or
+## data issues.  ``code`` identifies the error while ``message`` contains a
+## user-facing explanation.  ``details`` can include extra structured context.
+signal generation_error(code: String, message: String, details: Dictionary)
+
+## Strategies override this method to produce output.  The default
+## implementation simply returns an empty string so subclasses are not forced to
+## call ``super``.
+func generate(config: Dictionary) -> String:
+    return ""
+
+## Helper for subclasses that need to emit configurable errors.  The
+## configuration dictionary can provide a nested ``errors`` dictionary where
+## keys correspond to the error ``code`` value.  When the key is absent the
+## ``default_message`` parameter is used instead.
+func emit_configured_error(config: Dictionary, code: String, default_message: String, details: Dictionary = {}) -> void:
+    var message := default_message
+    if config.has("errors"):
+        var overrides := config.get("errors")
+        if typeof(overrides) == TYPE_DICTIONARY:
+            message = overrides.get(code, default_message)
+
+    emit_signal("generation_error", code, message, details)

--- a/name_generator/strategies/WordlistStrategy.gd
+++ b/name_generator/strategies/WordlistStrategy.gd
@@ -1,0 +1,84 @@
+## Strategy that assembles a name by sampling entries from authored word lists.
+##
+## The configuration dictionary supports the following keys:
+## - ``wordlist_paths``: Array of resource paths to [WordListResource] assets.
+## - ``use_weights``: Optional boolean flag that enables weighted selection when
+##   a list provides weight data.
+## - ``delimiter``: Optional string used to join the selected entries.  Defaults
+##   to a single space.
+## - ``errors``: Optional dictionary mapping error codes to custom messages.
+extends GeneratorStrategy
+class_name WordlistStrategy
+
+const ERROR_NO_PATHS := "wordlists_missing"
+const ERROR_LOAD_FAILED := "wordlist_load_failed"
+const ERROR_INVALID_RESOURCE := "wordlist_invalid_type"
+const ERROR_EMPTY_RESOURCE := "wordlist_empty"
+const ERROR_NO_SELECTION := "wordlists_no_selection"
+
+func generate(config: Dictionary) -> String:
+    var wordlist_paths := _normalize_paths(config.get("wordlist_paths", []))
+    if wordlist_paths.is_empty():
+        emit_configured_error(config, ERROR_NO_PATHS, "No word list resources were provided.")
+        return ""
+
+    var delimiter: String = config.get("delimiter", " ")
+    var use_weights: bool = config.get("use_weights", false)
+    var selections: Array[String] = []
+
+    for path in wordlist_paths:
+        var data := _load_wordlist(path, config)
+        if data.is_empty():
+            continue
+
+        var entries: Array = data.get("entries", [])
+        var weights: Array = data.get("weights", [])
+        var selection := _select_entry(entries, weights, use_weights)
+        if selection == null:
+            continue
+        selections.append(str(selection))
+
+    if selections.is_empty():
+        emit_configured_error(config, ERROR_NO_SELECTION, "No entries were available from the configured word lists.")
+        return ""
+
+    return selections.join(delimiter)
+
+func _normalize_paths(raw_paths: Variant) -> Array[String]:
+    var normalized: Array[String] = []
+    if raw_paths is PackedStringArray:
+        raw_paths = raw_paths.to_array()
+    if raw_paths is Array:
+        for path in raw_paths:
+            if typeof(path) == TYPE_STRING and not String(path).is_empty():
+                normalized.append(path)
+    return normalized
+
+func _load_wordlist(path: String, config: Dictionary) -> Dictionary:
+    var resource := ResourceLoader.load(path)
+    if resource == null:
+        emit_configured_error(config, ERROR_LOAD_FAILED, "Failed to load word list resource at '%s'." % path, {"path": path})
+        return {}
+
+    if not resource is WordListResource:
+        emit_configured_error(config, ERROR_INVALID_RESOURCE, "Resource at '%s' is not a WordListResource." % path, {"path": path})
+        return {}
+
+    var entries := resource.get_entries()
+    if entries.is_empty():
+        emit_configured_error(config, ERROR_EMPTY_RESOURCE, "Word list '%s' does not contain any entries." % path, {"path": path})
+        return {}
+
+    return {
+        "entries": entries,
+        "weights": resource.get_weights(),
+    }
+
+func _select_entry(entries: Array, weights: Array, use_weights: bool) -> Variant:
+    if entries.is_empty():
+        return null
+
+    if use_weights and not weights.is_empty():
+        return ArrayUtils.pick_weighted(entries, weights)
+
+    return ArrayUtils.pick_uniform(entries)

--- a/utils/ArrayUtils.gd
+++ b/utils/ArrayUtils.gd
@@ -1,0 +1,54 @@
+## Utility helpers for working with Array collections.
+##
+## This module wraps common random-selection functionality so that gameplay
+## systems can share consistent logic.  The helpers are written to be
+## deterministic whenever a custom [RandomNumberGenerator] instance is
+## provided, which is useful for tests and replay systems.  When no RNG is
+## provided the helpers will instantiate one on demand.
+class_name ArrayUtils
+extends RefCounted
+
+## Picks a single value from ``values`` using uniform probability.
+## Returns ``null`` when the input array is empty.
+static func pick_uniform(values: Array, rng: RandomNumberGenerator = null) -> Variant:
+    if values.is_empty():
+        return null
+
+    var local_rng := rng
+    if local_rng == null:
+        local_rng = RandomNumberGenerator.new()
+        local_rng.randomize()
+
+    var index := local_rng.randi_range(0, values.size() - 1)
+    return values[index]
+
+## Picks a single value from ``values`` using the supplied ``weights``.
+## ``weights`` must be the same size as ``values`` and every entry must be a
+## non-negative number.  When the weights do not contain any positive value
+## the selection gracefully falls back to ``pick_uniform``.
+static func pick_weighted(values: Array, weights: Array, rng: RandomNumberGenerator = null) -> Variant:
+    if values.is_empty() or weights.is_empty() or values.size() != weights.size():
+        return pick_uniform(values, rng)
+
+    var total_weight := 0.0
+    for weight in weights:
+        var normalized := max(float(weight), 0.0)
+        total_weight += normalized
+
+    if total_weight <= 0.0:
+        return pick_uniform(values, rng)
+
+    var local_rng := rng
+    if local_rng == null:
+        local_rng = RandomNumberGenerator.new()
+        local_rng.randomize()
+
+    var threshold := local_rng.randf() * total_weight
+    var cumulative := 0.0
+
+    for index in range(values.size()):
+        cumulative += max(float(weights[index]), 0.0)
+        if threshold <= cumulative:
+            return values[index]
+
+    return values.back()


### PR DESCRIPTION
## Summary
- add a reusable GeneratorStrategy base class with configurable error emission
- introduce a WordListResource and ArrayUtils helpers to support sampling entries
- implement WordlistStrategy to load configured word lists and generate joined names

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caace409ec83208ae53a402271921a