### PR TITLE
Add template strategy with deterministic RNG support

### DIFF
--- a/name_generator/NameGenerator.gd
+++ b/name_generator/NameGenerator.gd
@@ -1,0 +1,101 @@
+extends RefCounted
+class_name NameGenerator
+
+const GENERATOR_STRATEGY := preload("res://name_generator/strategies/GeneratorStrategy.gd")
+
+## Registry of known strategy script paths keyed by their public identifier.
+static var _strategy_paths := {
+    "template": "res://name_generator/strategies/TemplateStrategy.gd",
+}
+
+## Cache instantiated strategy singletons to avoid repeated allocations.
+static var _strategy_cache: Dictionary = {}
+
+static func register_strategy(identifier: String, script_path: String) -> void:
+    """
+    Register or override a generator strategy.
+
+    Supplying a ``script_path`` registers the given path. Passing an empty path
+    removes the registration, which can be useful for tests that need to mock
+    strategies.
+    """
+    if script_path == null or script_path.is_empty():
+        _strategy_paths.erase(identifier)
+        _strategy_cache.erase(identifier)
+        return
+
+    _strategy_paths[identifier] = script_path
+    _strategy_cache.erase(identifier)
+
+static func generate(config: Variant, rng: RandomNumberGenerator) -> Variant:
+    """
+    Generate a name using the strategy described by ``config``.
+
+    Returns either the generated ``String`` or an instance of
+    ``GeneratorStrategy.GeneratorError`` describing why the generation failed.
+    """
+    if typeof(config) != TYPE_DICTIONARY:
+        return _make_error(
+            "invalid_config_type",
+            "Generator configuration must be provided as a Dictionary.",
+            {
+                "received_type": typeof(config),
+                "type_name": Variant.get_type_name(typeof(config)),
+            },
+        )
+
+    var dict_config: Dictionary = config
+    if rng == null:
+        rng = RandomNumberGenerator.new()
+
+    if not dict_config.has("strategy"):
+        return _make_error(
+            "missing_strategy_key",
+            "Generator configuration is missing the 'strategy' key.",
+        )
+
+    var strategy_identifier = dict_config["strategy"]
+    if typeof(strategy_identifier) != TYPE_STRING:
+        return _make_error(
+            "invalid_strategy_type",
+            "Generator configuration 'strategy' must be a String identifier.",
+            {
+                "received_type": typeof(strategy_identifier),
+                "type_name": Variant.get_type_name(typeof(strategy_identifier)),
+            },
+        )
+
+    var strategy := _get_strategy_instance(strategy_identifier)
+    if strategy == null:
+        return _make_error(
+            "unknown_strategy",
+            "No generator strategy registered for identifier '%s'." % strategy_identifier,
+            {"identifier": strategy_identifier},
+        )
+
+    return strategy.generate(dict_config, rng)
+
+static func _get_strategy_instance(identifier: String) -> GeneratorStrategy:
+    if _strategy_cache.has(identifier):
+        return _strategy_cache[identifier]
+
+    if not _strategy_paths.has(identifier):
+        return null
+
+    var script_path: String = _strategy_paths[identifier]
+    var script := load(script_path)
+    if script == null:
+        return null
+
+    var instance = script.new()
+    if not (instance is GENERATOR_STRATEGY):
+        push_warning(
+            "Strategy at %s does not extend GeneratorStrategy and will be ignored." % script_path
+        )
+        return null
+
+    _strategy_cache[identifier] = instance
+    return instance
+
+static func _make_error(code: String, message: String, details: Dictionary = {}) -> GENERATOR_STRATEGY.GeneratorError:
+    return GENERATOR_STRATEGY.GeneratorError.new(code, message, details)

--- a/name_generator/strategies/TemplateStrategy.gd
+++ b/name_generator/strategies/TemplateStrategy.gd
@@ -1,0 +1,214 @@
+extends GeneratorStrategy
+class_name TemplateStrategy
+
+const NameGenerator = preload("res://name_generator/NameGenerator.gd")
+const RNGManager = preload("res://name_generator/utils/RNGManager.gd")
+
+const INTERNAL_DEPTH_KEY := "__template_depth"
+const INTERNAL_LINEAGE_KEY := "__template_lineage"
+const DEFAULT_MAX_DEPTH := 10
+
+## Default token pattern strips the surrounding brackets and any whitespace.
+const _TOKEN_START := "["
+const _TOKEN_END := "]"
+
+func _get_expected_config_keys() -> Dictionary:
+    return {
+        "required": PackedStringArray(["template_string"]),
+        "optional": {
+            "sub_generators": TYPE_DICTIONARY,
+            "max_depth": TYPE_INT,
+        },
+    }
+
+func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
+    var error := _validate_config(config)
+    if error:
+        return error
+
+    if rng == null:
+        rng = RandomNumberGenerator.new()
+
+    var template_string = config.get("template_string", "")
+    if typeof(template_string) != TYPE_STRING:
+        return _make_error(
+            "invalid_template_type",
+            "TemplateStrategy requires 'template_string' to be a String.",
+            {
+                "received_type": typeof(template_string),
+                "type_name": Variant.get_type_name(typeof(template_string)),
+            },
+        )
+
+    var sub_generators: Dictionary = {}
+    if config.has("sub_generators"):
+        var provided = config["sub_generators"]
+        if typeof(provided) != TYPE_DICTIONARY:
+            return _make_error(
+                "invalid_sub_generators_type",
+                "TemplateStrategy optional 'sub_generators' must be a Dictionary.",
+                {
+                    "received_type": typeof(provided),
+                    "type_name": Variant.get_type_name(typeof(provided)),
+                },
+            )
+        sub_generators = (provided as Dictionary).duplicate(true)
+
+    var max_depth := DEFAULT_MAX_DEPTH
+    if config.has("max_depth"):
+        var provided_max_depth = config["max_depth"]
+        if typeof(provided_max_depth) != TYPE_INT:
+            return _make_error(
+                "invalid_max_depth_type",
+                "TemplateStrategy optional 'max_depth' must be an int.",
+                {
+                    "received_type": typeof(provided_max_depth),
+                    "type_name": Variant.get_type_name(typeof(provided_max_depth)),
+                },
+            )
+        max_depth = int(provided_max_depth)
+        if max_depth <= 0:
+            return _make_error(
+                "invalid_max_depth_value",
+                "TemplateStrategy 'max_depth' must be greater than zero.",
+                {"max_depth": max_depth},
+            )
+
+    var current_depth := int(config.get(INTERNAL_DEPTH_KEY, 0))
+    var lineage: Array = []
+    if config.has(INTERNAL_LINEAGE_KEY):
+        var provided_lineage = config[INTERNAL_LINEAGE_KEY]
+        if provided_lineage is Array:
+            lineage = (provided_lineage as Array).duplicate(true)
+
+    if current_depth >= max_depth:
+        return _make_error(
+            "max_depth_exceeded",
+            "TemplateStrategy exceeded the maximum recursion depth of %d." % max_depth,
+            {
+                "max_depth": max_depth,
+                "lineage": lineage.duplicate(true),
+            },
+        )
+
+    return _render_template(
+        String(template_string),
+        sub_generators,
+        rng,
+        current_depth,
+        max_depth,
+        lineage,
+    )
+
+func _render_template(
+    template_string: String,
+    sub_generators: Dictionary,
+    rng: RandomNumberGenerator,
+    current_depth: int,
+    max_depth: int,
+    lineage: Array,
+) -> Variant:
+    var token_rngs: Dictionary = {}
+    var result := ""
+    var index := 0
+
+    while index < template_string.length():
+        var next_token_start := template_string.find(_TOKEN_START, index)
+        if next_token_start == -1:
+            result += template_string.substr(index, template_string.length() - index)
+            break
+
+        result += template_string.substr(index, next_token_start - index)
+        var token_close := template_string.find(_TOKEN_END, next_token_start + 1)
+        if token_close == -1:
+            return _make_error(
+                "unclosed_token",
+                "Template token starting at index %d is missing a closing ']'." % next_token_start,
+                {"start_index": next_token_start},
+            )
+
+        var token_key := template_string.substr(next_token_start + 1, token_close - next_token_start - 1).strip_edges()
+        if token_key.is_empty():
+            return _make_error(
+                "empty_token",
+                "Template token at index %d must specify a sub-generator key." % next_token_start,
+                {"start_index": next_token_start},
+            )
+
+        var token_value := _resolve_token(
+            token_key,
+            sub_generators,
+            rng,
+            token_rngs,
+            current_depth,
+            max_depth,
+            lineage,
+        )
+        if token_value is GeneratorStrategy.GeneratorError:
+            return token_value
+
+        result += String(token_value)
+        index = token_close + 1
+
+    return result
+
+func _resolve_token(
+    token_key: String,
+    sub_generators: Dictionary,
+    parent_rng: RandomNumberGenerator,
+    token_rngs: Dictionary,
+    current_depth: int,
+    max_depth: int,
+    lineage: Array,
+) -> Variant:
+    if not sub_generators.has(token_key):
+        return _make_error(
+            "missing_sub_generator",
+            "Template references unknown token '%s'." % token_key,
+            {
+                "token": token_key,
+                "available_tokens": sub_generators.keys(),
+            },
+        )
+
+    var token_config_variant = sub_generators[token_key]
+    if typeof(token_config_variant) != TYPE_DICTIONARY:
+        return _make_error(
+            "invalid_sub_generator_config",
+            "Configuration for token '%s' must be a Dictionary." % token_key,
+            {
+                "token": token_key,
+                "received_type": typeof(token_config_variant),
+                "type_name": Variant.get_type_name(typeof(token_config_variant)),
+            },
+        )
+
+    var token_config: Dictionary = (token_config_variant as Dictionary).duplicate(true)
+    token_config[INTERNAL_DEPTH_KEY] = current_depth + 1
+    if not token_config.has("max_depth"):
+        token_config["max_depth"] = max_depth
+    var updated_lineage := lineage.duplicate(true)
+    updated_lineage.append(token_key)
+    token_config[INTERNAL_LINEAGE_KEY] = updated_lineage
+
+    var token_rng: RandomNumberGenerator = token_rngs.get(token_key, null)
+    if token_rng == null:
+        token_rng = RNGManager.derive_child_rng(parent_rng, token_key, current_depth)
+        token_rngs[token_key] = token_rng
+
+    var generated_value := NameGenerator.generate(token_config, token_rng)
+    if generated_value is GeneratorStrategy.GeneratorError:
+        return generated_value
+
+    if typeof(generated_value) != TYPE_STRING:
+        return _make_error(
+            "invalid_generated_type",
+            "Generated value for token '%s' must be a String." % token_key,
+            {
+                "token": token_key,
+                "received_type": typeof(generated_value),
+                "type_name": Variant.get_type_name(typeof(generated_value)),
+            },
+        )
+
+    return generated_value

--- a/name_generator/utils/RNGManager.gd
+++ b/name_generator/utils/RNGManager.gd
@@ -1,0 +1,38 @@
+extends RefCounted
+class_name RNGManager
+
+"""
+Utility helpers for deriving deterministic random number generator streams.
+
+The Godot ``RandomNumberGenerator`` allows callers to control deterministic
+simulation by setting explicit seeds. When nested systems need their own
+streams, however, simply sharing the same RNG can introduce unintended state
+coupling. ``RNGManager`` offers helpers to deterministically derive additional
+streams from a parent RNG without mutating the parent state.
+"""
+
+static func derive_child_rng(
+    parent_rng: RandomNumberGenerator,
+    key: String,
+    depth: int = 0,
+) -> RandomNumberGenerator:
+    """
+    Create a deterministic child RNG for ``key`` using ``parent_rng`` as the root.
+
+    The resulting RNG uses a derived seed computed from the parent RNG's seed,
+    the provided ``key``, and the recursion ``depth``. This ensures that the
+    same inputs always generate an identical RNG stream while still keeping
+    streams for different keys or depths isolated from each other.
+    """
+    if parent_rng == null:
+        push_error("RNGManager.derive_child_rng requires a valid parent RNG instance.")
+        assert(false)
+        return RandomNumberGenerator.new()
+
+    var parent_seed := parent_rng.seed
+    var hash_input := "%s::%s::%s" % [parent_seed, key, depth]
+    var derived_seed := hash(hash_input)
+
+    var child := RandomNumberGenerator.new()
+    child.seed = derived_seed
+    return child


### PR DESCRIPTION
## Summary
- implement a template-driven strategy that expands bracket tokens using nested generator configs with deterministic RNG handling and recursion guards
- add a central NameGenerator registry that locates strategies, validates configs, and dispatches generation requests
- provide an RNGManager utility that derives child RandomNumberGenerator instances from a parent seed for reproducible nesting

## Testing
- godot --headless --run-tests *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caae4a0ad88320af1df35b5136f134