### PR TITLE
Add sample data resources for name generator

### DIFF
--- a/data/markov_models/arcane_elven_markov.tres
+++ b/data/markov_models/arcane_elven_markov.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" script_class_name="MarkovModelResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1_0"]
+
+[resource]
+order = 2
+start_sequences = PackedStringArray("ae", "el", "li")
+transitions = {
+"ae": {"l": 0.6, "r": 0.4},
+"el": {"a": 0.5, "i": 0.3, "y": 0.2},
+"la": {"r": 0.5, "n": 0.5},
+"li": {"a": 0.6, "s": 0.4},
+"ar": {"a": 0.2, "i": 0.3, "y": 0.5},
+"ri": {"n": 0.6, "s": 0.4},
+"in": {"a": 0.4, "y": 0.6},
+"ny": {"a": 0.7, "s": 0.3},
+"ya": {"n": 0.6, "r": 0.4}
+}
+locale = "Aelorian Enclaves"
+domain = "Arcane Highborn"
+rarity_notes = "Used for venerable spellcasters who have earned archival status within the enclave registries. Names from this model should surface sparingly in procedural content."

--- a/data/syllable_sets/desert_nomad.tres
+++ b/data/syllable_sets/desert_nomad.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class_name="SyllableSetResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1_0"]
+
+[resource]
+prefixes = PackedStringArray("Az", "Kar", "Zah", "Mal")
+middles = PackedStringArray("im", "ar", "ul", "aad")
+suffixes = PackedStringArray("ir", "ah", "een", "al")
+allow_empty_middle = false
+locale = "Shifting Dunes Tribes"
+domain = "Nomad Clans"

--- a/data/syllable_sets/elven_forest.tres
+++ b/data/syllable_sets/elven_forest.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class_name="SyllableSetResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1_0"]
+
+[resource]
+prefixes = PackedStringArray("Ae", "Eli", "Lia", "Syl", "Tha")
+middles = PackedStringArray("ri", "len", "tha", "ria")
+suffixes = PackedStringArray("n", "th", "riel", "wyn")
+allow_empty_middle = true
+locale = "Elarian Woodlands"
+domain = "Forest Sentinels"

--- a/data/wordlists/fantasy_dwarven_male.tres
+++ b/data/wordlists/fantasy_dwarven_male.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("Baern", "Gimli", "Thorin", "Rurik", "Dain", "Orsik")
+weighted_entries = []

--- a/data/wordlists/weapon_adjectives.tres
+++ b/data/wordlists/weapon_adjectives.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray()
+weighted_entries = [{"value": "Ancient", "weight": 0.6}, {"value": "Razor-edged", "weight": 1.2}, {"value": "Stormforged", "weight": 1.5}, {"value": "Bloodthirsty", "weight": 0.9}, {"value": "Moonlit", "weight": 0.4}]

--- a/name_generator/resources/MarkovModelResource.gd
+++ b/name_generator/resources/MarkovModelResource.gd
@@ -1,0 +1,30 @@
+@tool
+extends Resource
+
+class_name MarkovModelResource
+
+## MarkovModelResource encapsulates a precomputed Markov chain for name generation.
+## Designers can serialize a simple character-transition table to keep runtime logic
+## focused on selection rather than training.
+
+@export_group("Model configuration")
+## The order of the Markov chain, e.g., 1 for unigram, 2 for bigram models.
+@export_range(1, 5, 1)
+var order: int = 2
+
+## Starting sequences seeded before generating characters.
+@export var start_sequences: PackedStringArray = PackedStringArray()
+
+## Transition probability table keyed by state -> dictionary of next character weights.
+@export var transitions: Dictionary = {}
+
+@export_group("Metadata")
+## Locale hint describing the culture or language inspiration for the model.
+@export var locale: String = ""
+
+## Domain or thematic usage (e.g., "Arcane", "Military", "Cyberpunk").
+@export var domain: String = ""
+
+## Optional notes about rarity or curation guidance for designers.
+@export_multiline
+var rarity_notes: String = ""


### PR DESCRIPTION
## Summary
- add MarkovModelResource script for configuring serialized Markov chains and metadata
- seed word list resources showing both uniform and weighted configurations
- provide sample syllable sets and an arcane elven Markov model with locale, domain, and rarity notes

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68caaea43a508320966399c173e56126