### PR TITLE
Add generator strategy test suite and runner

### DIFF
--- a/name_generator/tests/README.md
+++ b/name_generator/tests/README.md
@@ -1,3 +1,32 @@
 # Tests
 
-This placeholder file documents the purpose of the `tests` directory. Add implementation scripts or assets here as the module evolves.
+This directory now contains automated coverage for the name generator module. The suite focuses on the shared `GeneratorStrategy` contract and exercises happy-path name creation, validation failures, and deterministic RNG behaviour using a purpose-built mock implementation.
+
+## Structure
+
+- `test_generator_strategy.gd` – Table-driven checks that verify configuration validation helpers, enforce error metadata, and confirm deterministic sequences generated with identical RNG seeds.
+
+## Running the suite
+
+Use the project-wide runner script to execute every registered suite:
+
+```bash
+godot4 --headless --path . --script res://tests/run_all_tests.gd
+```
+
+### Expected output
+
+When all tests succeed you should see console logs similar to:
+
+```
+Running suite: Generator Strategy Suite
+  Total: 5
+  Passed: 5
+  Failed: 0
+  ✅ All tests passed in suite: Generator Strategy Suite
+
+Test summary: 5 passed, 0 failed, 5 total.
+ALL TESTS PASSED
+```
+
+Any failures are reported with the test name and human-readable diagnostics to simplify debugging for engineers integrating new strategies.

--- a/name_generator/tests/test_generator_strategy.gd
+++ b/name_generator/tests/test_generator_strategy.gd
@@ -1,0 +1,200 @@
+extends RefCounted
+
+const GeneratorStrategy := preload("res://name_generator/strategies/GeneratorStrategy.gd")
+const ArrayUtils := preload("res://name_generator/utils/ArrayUtils.gd")
+
+class MockStrategy:
+    extends GeneratorStrategy
+
+    func _get_expected_config_keys() -> Dictionary:
+        return {
+            "required": PackedStringArray(["values"]),
+            "optional": {
+                "uppercase": TYPE_BOOL,
+                "prefix": TYPE_STRING,
+            },
+        }
+
+    func generate(config: Dictionary, rng: RandomNumberGenerator) -> String:
+        var error := _validate_config(config)
+        if error:
+            var payload := error.to_dict()
+            push_error("MockStrategy received invalid config: %s" % payload)
+            assert(false, error.message)
+
+        var normalized: Array[String] = []
+        for value in config["values"]:
+            normalized.append(String(value))
+
+        var selected: String = ArrayUtils.pick_random_deterministic(normalized, rng)
+
+        if config.get("uppercase", false):
+            selected = selected.to_upper()
+
+        if config.has("prefix"):
+            selected = "%s%s" % [String(config["prefix"]), selected]
+
+        return selected
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+    _run_test("happy_path_generates_expected_format", func(): _test_happy_path())
+    _run_test("validation_fails_when_config_not_dictionary", func(): _test_invalid_config_type())
+    _run_test("validation_fails_when_required_key_missing", func(): _test_missing_required_key())
+    _run_test("validation_fails_on_optional_type_mismatch", func(): _test_invalid_optional_type())
+    _run_test("deterministic_rng_produces_reproducible_sequences", func(): _test_deterministic_rng())
+
+    return {
+        "suite": "GeneratorStrategy",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var error_message = ""
+    var success := true
+
+    var result = callable.call()
+    if result != null:
+        success = false
+        error_message = String(result)
+
+    if success:
+        _passed += 1
+    else:
+        _failed += 1
+        _failures.append({
+            "name": name,
+            "message": error_message,
+        })
+
+func _test_happy_path() -> Variant:
+    var strategy := MockStrategy.new()
+    var rng := RandomNumberGenerator.new()
+    rng.seed = 1337
+
+    var config := {
+        "values": ["nova", "luna", "sol"],
+        "uppercase": true,
+        "prefix": "Star-",
+    }
+
+    var result := strategy.generate(config, rng)
+
+    if not result.begins_with("Star-"):
+        return "Generated value must include the configured prefix."
+
+    var prefix_length := String(config["prefix"]).length()
+    var core := result.substr(prefix_length, result.length() - prefix_length)
+
+    if core != core.to_upper():
+        return "Generated value must honor the uppercase flag."
+
+    var allowed: Array[String] = []
+    for value in config["values"]:
+        allowed.append(String(value).to_upper())
+
+    if not allowed.has(core):
+        return "Generated value must come from the provided pool."
+
+    return null
+
+func _test_invalid_config_type() -> Variant:
+    var strategy := MockStrategy.new()
+    var error := strategy._validate_config("not a dictionary")
+
+    if error == null:
+        return "Validation should fail when the config is not a dictionary."
+
+    if error.code != "invalid_config_type":
+        return "Unexpected error code %s for invalid config type." % error.code
+
+    return null
+
+func _test_missing_required_key() -> Variant:
+    var strategy := MockStrategy.new()
+    var error := strategy._validate_config({})
+
+    if error == null:
+        return "Validation should fail when required keys are missing."
+
+    if error.code != "missing_required_keys":
+        return "Unexpected error code %s when required keys are missing." % error.code
+
+    if not error.details.has("missing"):
+        return "Error details should list the missing keys."
+
+    var missing: PackedStringArray = error.details["missing"]
+    if not missing.has("values"):
+        return "Missing keys list should include 'values'."
+
+    return null
+
+func _test_invalid_optional_type() -> Variant:
+    var strategy := MockStrategy.new()
+    var config := {
+        "values": ["atlas"],
+        "uppercase": "yes please",
+    }
+
+    var error := strategy._validate_config(config)
+
+    if error == null:
+        return "Validation should fail when optional keys have the wrong type."
+
+    if error.code != "invalid_key_type":
+        return "Unexpected error code %s for invalid key types." % error.code
+
+    if error.details.get("key", "") != "uppercase":
+        return "Error details should identify the invalid key."
+
+    if error.details.get("expected_type", -1) != TYPE_BOOL:
+        return "Error details should describe the expected type for the invalid key."
+
+    return null
+
+func _test_deterministic_rng() -> Variant:
+    var strategy := MockStrategy.new()
+    var config := {
+        "values": ["aurora", "selene", "lyra", "draco", "orion"],
+    }
+
+    var first_rng := RandomNumberGenerator.new()
+    first_rng.seed = 42
+
+    var second_rng := RandomNumberGenerator.new()
+    second_rng.seed = 42
+
+    var first_sequence: Array[String] = []
+    var second_sequence: Array[String] = []
+
+    for i in range(5):
+        first_sequence.append(strategy.generate(config, first_rng))
+        second_sequence.append(strategy.generate(config, second_rng))
+
+    if first_sequence != second_sequence:
+        return "Sequences generated with identical seeds must match."
+
+    var alternate_rng := RandomNumberGenerator.new()
+    alternate_rng.seed = 314159
+
+    var alternate_sequence: Array[String] = []
+    for i in range(5):
+        alternate_sequence.append(strategy.generate(config, alternate_rng))
+
+    if alternate_sequence == first_sequence:
+        return "Different seeds should produce a different sequence of values."
+
+    return null

--- a/project.godot
+++ b/project.godot
@@ -31,6 +31,8 @@ imported_folders=PackedStringArray(
         "res://name_generator/strategies",
         "res://name_generator/utils",
         "res://name_generator/tools",
-        "res://name_generator/tests"
+        "res://name_generator/tests",
+        "res://tests",
+        "res://tests/test_assets"
 )
 

--- a/tests/run_all_tests.gd
+++ b/tests/run_all_tests.gd
@@ -1,0 +1,109 @@
+extends SceneTree
+
+const MANIFEST_PATH := "res://tests/tests_manifest.json"
+
+func _initialize() -> void:
+    call_deferred("_run")
+
+func _run() -> void:
+    var exit_code := _execute()
+    quit(exit_code)
+
+func _execute() -> int:
+    if not FileAccess.file_exists(MANIFEST_PATH):
+        push_error("Test manifest not found at %s" % MANIFEST_PATH)
+        return 1
+
+    var file := FileAccess.open(MANIFEST_PATH, FileAccess.READ)
+    if file == null:
+        push_error("Unable to open test manifest at %s" % MANIFEST_PATH)
+        return 1
+
+    var text := file.get_as_text()
+    var json := JSON.new()
+    var parse_error := json.parse(text)
+    if parse_error != OK:
+        push_error("Failed to parse test manifest JSON: %s" % json.get_error_message())
+        return 1
+
+    var manifest := json.data
+    if manifest == null or not (manifest is Dictionary):
+        push_error("Test manifest must be a dictionary with a 'suites' array.")
+        return 1
+
+    var suites := manifest.get("suites", [])
+    if suites.is_empty():
+        push_warning("No test suites declared in manifest. Nothing to run.")
+        return 0
+
+    var overall_success := true
+    var aggregate_total := 0
+    var aggregate_passed := 0
+    var aggregate_failed := 0
+
+    for entry in suites:
+        var suite_info := entry if entry is Dictionary else {}
+        var suite_name := suite_info.get("name", "Unnamed Suite")
+        var suite_path := suite_info.get("path", "")
+
+        print("Running suite: %s" % suite_name)
+
+        if suite_path == "":
+            overall_success = false
+            print("  ✗ Suite path missing from manifest entry.")
+            continue
+
+        var script := load(suite_path)
+        if script == null:
+            overall_success = false
+            print("  ✗ Unable to load suite script at %s" % suite_path)
+            continue
+
+        var suite_instance = script.new()
+        if suite_instance == null or not suite_instance.has_method("run"):
+            overall_success = false
+            print("  ✗ Suite script %s must implement a `run()` method." % suite_path)
+            continue
+
+        var suite_result = suite_instance.run()
+        var total := 0
+        var passed := 0
+        var failed := 0
+        var failures := []
+
+        if suite_result is Dictionary:
+            total = int(suite_result.get("total", 0))
+            passed = int(suite_result.get("passed", 0))
+            failed = int(suite_result.get("failed", 0))
+            failures = suite_result.get("failures", [])
+        else:
+            overall_success = false
+            print("  ✗ Suite %s returned an unexpected result type." % suite_name)
+            continue
+
+        aggregate_total += total
+        aggregate_passed += passed
+        aggregate_failed += failed
+
+        print("  Total: %d" % total)
+        print("  Passed: %d" % passed)
+        print("  Failed: %d" % failed)
+
+        if not failures.is_empty():
+            overall_success = false
+            for failure in failures:
+                var failure_info := failure if failure is Dictionary else {}
+                var test_name := failure_info.get("name", "Unnamed Test")
+                var message := failure_info.get("message", "")
+                print("    ✗ %s -- %s" % [test_name, message])
+        else:
+            print("  ✅ All tests passed in suite: %s" % suite_name)
+
+    print("\nTest summary: %d passed, %d failed, %d total." % [aggregate_passed, aggregate_failed, aggregate_total])
+
+    if overall_success:
+        print("ALL TESTS PASSED")
+        return 0
+
+    print("TESTS FAILED")
+    return 1

--- a/tests/test_assets/README.md
+++ b/tests/test_assets/README.md
@@ -1,0 +1,3 @@
+# Test Assets
+
+This folder hosts data fixtures consumed by automated test suites. The current generator strategy tests operate entirely in code, so no external fixtures are required yet. Add new resources here when future suites need sample syllable sets, word lists, or serialized strategy configs.

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -1,0 +1,8 @@
+{
+  "suites": [
+    {
+      "name": "Generator Strategy Suite",
+      "path": "res://name_generator/tests/test_generator_strategy.gd"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a manifest-driven test runner script for executing Godot-based suites
- implement generator strategy tests that cover configuration validation and deterministic RNG behaviour
- document the execution command, expected output, and add a placeholder for future fixtures

## Testing
- `godot4 --headless --path . --script res://tests/run_all_tests.gd` *(fails: `godot4` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caaeb97e5c8320b50a2ca6ec6bb258