### PR TITLE
Implement hybrid name generation pipeline

### DIFF
--- a/name_generator/NameGenerator.gd
+++ b/name_generator/NameGenerator.gd
@@ -1,136 +1,186 @@
-
 extends Node
 class_name NameGenerator
 
-## High-level façade that exposes name generation utilities to the project.
-##
-## The autoload intentionally stays lightweight for now. It focuses on providing
-## deterministic access to existing utility helpers so other systems can begin
-## experimenting with content pipelines before the full generator matrix is
-## implemented.
+## High-level façade that coordinates the different generation strategies.
+## The singleton is registered as a Godot autoload so game code and editor
+## tooling can request names via a consistent API.
 
-func pick_from_list(options: Array) -> Variant:
-    """
-    Select an entry from ``options`` using the shared ``RNGManager`` instance.
+const DEFAULT_STREAM_PREFIX := "name_generator"
 
-    The helper reuses ``ArrayUtils`` so we benefit from its input validation and
-    deterministic behaviour. When additional generation strategies come online we
-    can expand this façade to route requests to dedicated modules.
-    """
+const GeneratorStrategy := preload("res://name_generator/strategies/GeneratorStrategy.gd")
+const WordlistStrategy := preload("res://name_generator/strategies/WordlistStrategy.gd")
+const SyllableChainStrategy := preload("res://name_generator/strategies/SyllableChainStrategy.gd")
+const TemplateStrategy := preload("res://name_generator/strategies/TemplateStrategy.gd")
+const MarkovChainStrategy := preload("res://name_generator/strategies/MarkovChainStrategy.gd")
+const HybridStrategy := preload("res://name_generator/strategies/HybridStrategy.gd")
+const ArrayUtils := preload("res://name_generator/utils/ArrayUtils.gd")
+
+var _strategies: Dictionary = {}
+
+func _ready() -> void:
+    _register_builtin_strategies()
+
+func pick_from_list(options: Array, stream_name: String = "utility_name_list") -> Variant:
     ArrayUtils.assert_not_empty(options, "Name options")
-    var rng := RNGManager.get_rng()
-    return ArrayUtils.pick_random_deterministic(options, rng)
+    var rng := _acquire_rng(stream_name)
+    return ArrayUtils.pick_uniform(options, rng)
 
-
-func pick_weighted(entries: Array) -> Variant:
-    """
-    Select a weighted entry from ``entries`` using the shared RNG.
-
-    This ensures all consumers derive randomness from a single seed source. The
-    API mirrors ``ArrayUtils.pick_weighted_random_deterministic`` but keeps the
-    higher-level naming consistent for autoload consumers.
-    """
+func pick_weighted(entries: Array, stream_name: String = "utility_name_weighted") -> Variant:
     ArrayUtils.assert_not_empty(entries, "Weighted name entries")
-    var rng := RNGManager.get_rng()
-    return ArrayUtils.pick_weighted_random_deterministic(entries, rng)
+    var rng := _acquire_rng(stream_name)
+    return ArrayUtils.pick_weighted(entries, rng)
 
-
-const GENERATOR_STRATEGY := preload("res://name_generator/strategies/GeneratorStrategy.gd")
-
-## Registry of known strategy script paths keyed by their public identifier.
-static var _strategy_paths := {
-    "template": "res://name_generator/strategies/TemplateStrategy.gd",
-}
-
-## Cache instantiated strategy singletons to avoid repeated allocations.
-static var _strategy_cache: Dictionary = {}
-
-static func register_strategy(identifier: String, script_path: String) -> void:
-    """
-    Register or override a generator strategy.
-
-    Supplying a ``script_path`` registers the given path. Passing an empty path
-    removes the registration, which can be useful for tests that need to mock
-    strategies.
-    """
-    if script_path == null or script_path.is_empty():
-        _strategy_paths.erase(identifier)
-        _strategy_cache.erase(identifier)
+func register_strategy(strategy_id: String, strategy: GeneratorStrategy) -> void:
+    var normalized := _normalize_strategy_id(strategy_id)
+    if normalized.is_empty():
+        push_error("Strategy identifiers must be non-empty strings.")
         return
 
-    _strategy_paths[identifier] = script_path
-    _strategy_cache.erase(identifier)
+    if strategy == null:
+        push_error("Strategy '%s' must reference a valid GeneratorStrategy instance." % normalized)
+        return
 
-static func generate(config: Variant, rng: RandomNumberGenerator) -> Variant:
-    """
-    Generate a name using the strategy described by ``config``.
+    if not (strategy is GeneratorStrategy):
+        push_error("Strategy '%s' must extend GeneratorStrategy." % normalized)
+        return
 
-    Returns either the generated ``String`` or an instance of
-    ``GeneratorStrategy.GeneratorError`` describing why the generation failed.
-    """
+    _strategies[normalized] = strategy
+
+func unregister_strategy(strategy_id: String) -> void:
+    var normalized := _normalize_strategy_id(strategy_id)
+    if normalized.is_empty():
+        return
+    _strategies.erase(normalized)
+
+func has_strategy(strategy_id: String) -> bool:
+    return _strategies.has(_normalize_strategy_id(strategy_id))
+
+func list_strategies() -> PackedStringArray:
+    var result := PackedStringArray()
+    for key in _strategies.keys():
+        result.append(String(key))
+    result.sort()
+    return result
+
+func generate(config: Variant, override_rng: RandomNumberGenerator = null) -> Variant:
+    var validation_error := _validate_request_config(config, override_rng != null)
+    if validation_error:
+        return validation_error
+
+    var request: Dictionary = config
+    var strategy_id := _normalize_strategy_id(request["strategy"])
+    var strategy: GeneratorStrategy = _strategies.get(strategy_id, null)
+    if strategy == null:
+        return _make_error(
+            "unknown_strategy",
+            "Strategy '%s' is not registered." % strategy_id,
+            {"strategy": strategy_id},
+        )
+
+    var stream_name := _resolve_stream_name(request, strategy_id)
+    var rng := override_rng if override_rng != null else _acquire_rng(stream_name)
+
+    var strategy_config := _extract_strategy_config(request)
+    var result := strategy.generate(strategy_config, rng)
+
+    if result is GeneratorStrategy.GeneratorError:
+        return result.to_dict()
+
+    return result
+
+func _register_builtin_strategies() -> void:
+    var builtins := _get_builtin_strategy_map()
+    for identifier in builtins.keys():
+        register_strategy(identifier, builtins[identifier])
+
+func _get_builtin_strategy_map() -> Dictionary:
+    return {
+        "wordlist": WordlistStrategy.new(),
+        "syllable": SyllableChainStrategy.new(),
+        "template": TemplateStrategy.new(),
+        "markov": MarkovChainStrategy.new(),
+        "hybrid": HybridStrategy.new(),
+    }
+
+func _normalize_strategy_id(value: Variant) -> String:
+    if typeof(value) != TYPE_STRING:
+        return ""
+    return String(value).strip_edges()
+
+func _validate_request_config(config: Variant, allow_missing_seed: bool) -> Dictionary:
     if typeof(config) != TYPE_DICTIONARY:
         return _make_error(
             "invalid_config_type",
-            "Generator configuration must be provided as a Dictionary.",
+            "NameGenerator.generate expects a Dictionary configuration.",
             {
                 "received_type": typeof(config),
                 "type_name": Variant.get_type_name(typeof(config)),
             },
         )
 
-    var dict_config: Dictionary = config
-    if rng == null:
-        rng = RandomNumberGenerator.new()
+    var dictionary: Dictionary = config
+    if not dictionary.has("strategy"):
+        return _make_error("missing_strategy", "Configuration must include a 'strategy' key.")
 
-    if not dict_config.has("strategy"):
+    var normalized_id := _normalize_strategy_id(dictionary["strategy"])
+    if normalized_id.is_empty():
         return _make_error(
-            "missing_strategy_key",
-            "Generator configuration is missing the 'strategy' key.",
+            "invalid_strategy_identifier",
+            "Strategy identifiers must be non-empty strings.",
         )
 
-    var strategy_identifier = dict_config["strategy"]
-    if typeof(strategy_identifier) != TYPE_STRING:
+    if not allow_missing_seed and not dictionary.has("seed"):
+        return _make_error("missing_seed", "Configuration must include a 'seed' value.")
+
+    if dictionary.has("rng_stream") and typeof(dictionary["rng_stream"]) != TYPE_STRING:
         return _make_error(
-            "invalid_strategy_type",
-            "Generator configuration 'strategy' must be a String identifier.",
+            "invalid_stream_name",
+            "The 'rng_stream' override must be a string when provided.",
             {
-                "received_type": typeof(strategy_identifier),
-                "type_name": Variant.get_type_name(typeof(strategy_identifier)),
+                "received_type": typeof(dictionary["rng_stream"]),
+                "type_name": Variant.get_type_name(typeof(dictionary["rng_stream"])),
             },
         )
 
-    var strategy := _get_strategy_instance(strategy_identifier)
-    if strategy == null:
-        return _make_error(
-            "unknown_strategy",
-            "No generator strategy registered for identifier '%s'." % strategy_identifier,
-            {"identifier": strategy_identifier},
-        )
+    return null
 
-    return strategy.generate(dict_config, rng)
+func _resolve_stream_name(config: Dictionary, strategy_id: String) -> String:
+    if config.has("rng_stream"):
+        return String(config["rng_stream"])
 
-static func _get_strategy_instance(identifier: String) -> GeneratorStrategy:
-    if _strategy_cache.has(identifier):
-        return _strategy_cache[identifier]
+    if config.has("seed"):
+        var seed_string := String(config["seed"]).strip_edges()
+        if seed_string.is_empty():
+            seed_string = "seed"
+        return "%s::%s" % [strategy_id, seed_string]
 
-    if not _strategy_paths.has(identifier):
-        return null
+    return "%s::%s" % [DEFAULT_STREAM_PREFIX, strategy_id]
 
-    var script_path: String = _strategy_paths[identifier]
-    var script := load(script_path)
-    if script == null:
-        return null
+func _extract_strategy_config(config: Dictionary) -> Dictionary:
+    var strategy_config := {}
+    for key in config.keys():
+        match key:
+            "strategy", "rng_stream":
+                pass
+            _:
+                strategy_config[key] = config[key]
+    return strategy_config
 
-    var instance = script.new()
-    if not (instance is GENERATOR_STRATEGY):
-        push_warning(
-            "Strategy at %s does not extend GeneratorStrategy and will be ignored." % script_path
-        )
-        return null
+func _acquire_rng(stream_name: String) -> RandomNumberGenerator:
+    if Engine.has_singleton("RNGManager"):
+        var manager := Engine.get_singleton("RNGManager")
+        if manager != null and manager.has_method("get_rng"):
+            var rng := manager.call("get_rng", stream_name)
+            if rng is RandomNumberGenerator:
+                return rng
 
-    _strategy_cache[identifier] = instance
-    return instance
+    var fallback := RandomNumberGenerator.new()
+    fallback.randomize()
+    return fallback
 
-static func _make_error(code: String, message: String, details: Dictionary = {}) -> GENERATOR_STRATEGY.GeneratorError:
-    return GENERATOR_STRATEGY.GeneratorError.new(code, message, details)
-
+func _make_error(code: String, message: String, details: Dictionary = {}) -> Dictionary:
+    return {
+        "code": code,
+        "message": message,
+        "details": details.duplicate(true),
+    }

--- a/name_generator/README.md
+++ b/name_generator/README.md
@@ -1,21 +1,78 @@
 # Name Generator Module
 
-This module mirrors the planned runtime architecture for the random name generator. The nested directories keep resources, processing strategies, utilities, development tools, and automated tests separated so engineers can evolve each concern independently.
+This module mirrors the runtime architecture described in `DevDoc.txt`. It keeps
+strategy implementations, reusable resources, deterministic RNG plumbing, and
+automated tests in discrete folders so engineers can evolve each concern without
+colliding.
 
-- `resources/` – Static Godot resources, scriptable objects, and data packs distributed with the module.
-- `strategies/` – Script logic implementing individual name-generation approaches.
-- `utils/` – Shared helper scripts and low-level abstractions consumed across strategies.
-- `tools/` – Editor and command-line helpers that assist with authoring or validating name data.
-- `tests/` – Automated regression or integration tests that exercise the generator pipeline.
+- `resources/` – Custom Godot resources (word lists, syllable sets, Markov
+  models) that can be authored inside the editor.
+- `strategies/` – Script logic implementing the Strategy pattern. Each
+  `GeneratorStrategy` subclass consumes a configuration dictionary and a seeded
+  `RandomNumberGenerator` instance.
+- `utils/` – Shared helper scripts such as deterministic RNG routing and array
+  selection helpers.
+- `tools/` – Editor and command-line utilities that support content authoring.
+- `tests/` – Regression suites executed via `tests/run_all_tests.gd`.
 
-Place new scripts in the appropriate folder and update the Godot project settings when additional resource directories are required.
+## Runtime singletons
 
-## Random Number Coordination
+`project.godot` registers two autoloads under the `name_generator/` directory:
 
-The `autoloads/RNGManager.gd` singleton exposes deterministic `RandomNumberGenerator`
-streams keyed by a descriptive name. Request RNGs via
-`RNGManager.get_rng("gameplay")` instead of creating ad-hoc instances so the
-master seed can drive reproducible results across gameplay systems, tools, and
-tests. Use `set_master_seed()` or `randomize_master_seed()` to control the global
-seed, and persist/restore state with `save_state()` / `load_state()` when saving
-or loading sessions.
+- `RNGManager.gd` centralises deterministic random number generation. Call
+  `RNGManager.set_master_seed()` (or `randomize_master_seed()`) during startup,
+  then request isolated streams via `RNGManager.get_rng("gameplay")`. The
+  manager can serialise its state with `save_state()` / `load_state()` so save
+  files reproduce identical random sequences.
+- `NameGenerator.gd` is the façade exposed to gameplay code and tools. It
+  registers built-in strategies (`wordlist`, `syllable`, `template`, `markov`,
+  and `hybrid`), exposes helpers (`pick_from_list`, `pick_weighted`), and routes
+  `generate(config)` calls to the correct strategy while sourcing RNG streams
+  from `RNGManager`.
+
+## Strategy overview
+
+All strategies extend `GeneratorStrategy`, which standardises configuration
+validation and error reporting. The following implementations ship by default:
+
+- **WordlistStrategy** – Combines entries from one or more
+  `WordListResource` files. Supports weighted selection when the resource
+  defines weights.
+- **SyllableChainStrategy** – Concatenates syllables from a
+  `SyllableSetResource`, smoothing boundaries and honouring minimum-length
+  constraints.
+- **TemplateStrategy** – Expands a template string containing bracketed tokens
+  (e.g. `[title] of [place]`). Each token executes another NameGenerator
+  configuration, enabling recursive composition.
+- **MarkovChainStrategy** – Walks through a `MarkovModelResource` to emit names
+  that mirror the training data’s statistical patterns.
+- **HybridStrategy** – Executes a sequence of sub-configurations and exposes
+  their results to later steps via `$alias` placeholders. This formalises the
+  “hybrid generation” workflow described in the design document and provides a
+  single configuration object that can chain every other strategy.
+
+See `devdocs/strategies.md` for authoring guidance and
+`tests/test_assets/*.tres` for small sample resources used by the automated
+suites.
+
+## Deterministic helpers
+
+`ArrayUtils.gd` contains deterministic helpers that never touch Godot’s global
+RNG state:
+
+- `pick_uniform` / `pick_random_deterministic` – Select a single element from an
+  array.
+- `pick_weighted` / `pick_weighted_random_deterministic` – Select an element
+  using weights supplied as dictionaries or `[value, weight]` pairs.
+- `handle_empty_with_fallback` – Provide a fallback when an array is empty while
+  still surfacing deterministic assertions in tests.
+
+`name_generator/utils/RNGManager.gd` (class `RNGStreamRouter`) derives child RNG
+instances from a root seed. Strategies use it to create per-token streams during
+nested generation without mutating the parent RNG state.
+
+## Tests
+
+Run `godot --headless --script res://tests/run_all_tests.gd` to execute the
+suite. The manifest currently includes the general `GeneratorStrategy` tests and
+an integration suite that validates the hybrid generation pipeline.

--- a/name_generator/resources/MarkovModelResource.gd
+++ b/name_generator/resources/MarkovModelResource.gd
@@ -1,75 +1,33 @@
 @tool
 extends Resource
-
-
 class_name MarkovModelResource
 
-## MarkovModelResource encapsulates a precomputed Markov chain for name generation.
-## Designers can serialize a simple character-transition table to keep runtime logic
-## focused on selection rather than training.
+## Serializable Markov chain model consumed by MarkovChainStrategy.
+## The resource keeps generation lightweight by precomputing the transition
+## table ahead of time. Designers can author the data directly in the inspector
+## or rely on tooling scripts in `name_generator/tools`.
 
-@export_group("Model configuration")
-## The order of the Markov chain, e.g., 1 for unigram, 2 for bigram models.
-@export_range(1, 5, 1)
-var order: int = 2
-
-## Starting sequences seeded before generating characters.
-@export var start_sequences: PackedStringArray = PackedStringArray()
-
-## Transition probability table keyed by state -> dictionary of next character weights.
-@export var transitions: Dictionary = {}
-
-@export_group("Metadata")
-## Locale hint describing the culture or language inspiration for the model.
-@export var locale: String = ""
-
-## Domain or thematic usage (e.g., "Arcane", "Military", "Cyberpunk").
-@export var domain: String = ""
-
-## Optional notes about rarity or curation guidance for designers.
-@export_multiline
-var rarity_notes: String = ""
-
-
-
-## MarkovModelResource describes a discrete-time Markov chain used to assemble
-## generated names from weighted token transitions. Designers configure the
-## resource inside the Godot editor and strategies consume it at runtime to
-## produce deterministic-yet-flexible name sequences.
-
-## Ordered collection of every token that can appear in the model. Tokens act as
-## both the emitted syllable/character and the identifier for transition
-## lookups. Including all tokens here enables simple validation and assists
-## tooling when presenting possible transitions in editors.
+@export_group("Model")
+@export_range(1, 8, 1) var order: int = 2
 @export var states: PackedStringArray = PackedStringArray()
-
-## Weighted transitions for every token/state. Each key should map to an
-## Array[Dictionary] where dictionaries use:
-## - `token` ([String]): destination token/state identifier.
-## - `weight` ([float]): positive weight used during sampling.
-## - `temperature` ([float], optional): overrides the effective temperature when
-##   sampling the transition.
-@export var transitions: Dictionary = {}
-
-## Collection of initial token candidates. Each entry follows the same structure
-## as items in `transitions` — `token`, `weight`, and optional `temperature`.
-## Entries may reference any token from `states` including those present in
-## `end_tokens` when the model allows immediate termination.
 @export var start_tokens: Array[Dictionary] = []
-
-## Tokens that signal termination. When generation produces any token listed
-## here the strategy stops without appending additional content. Designers
-## typically include an explicit terminator token such as "<END>" or an empty
-## string.
+@export var transitions: Dictionary = {}
 @export var end_tokens: PackedStringArray = PackedStringArray()
-
-## Default temperature scalar applied during sampling. Values greater than 1.0
-## flatten the distribution while values between 0 and 1 push the model toward
-## higher-probability tokens. Setting the value to 1 leaves weights unchanged.
-@export_range(0.01, 10.0, 0.01) var default_temperature: float = 1.0
-
-## Optional per-token temperature overrides. When a key matches the token being
-## sampled the specified value supersedes `default_temperature` for the duration
-## of that selection.
+@export var default_temperature: float = 1.0
 @export var token_temperatures: Dictionary = {}
 
+@export_group("Metadata")
+@export var locale: String = ""
+@export var domain: String = ""
+@export_multiline var notes: String = ""
+
+func has_state(token: String) -> bool:
+    return states.has(token)
+
+func get_transition_block(token: String) -> Array:
+    if not transitions.has(token):
+        return []
+    var block := transitions[token]
+    if block is Array:
+        return block
+    return []

--- a/name_generator/strategies/GeneratorStrategy.gd
+++ b/name_generator/strategies/GeneratorStrategy.gd
@@ -1,77 +1,15 @@
-
-## Abstract base class for name generation strategies.
-##
-## Strategies consume a configuration dictionary and emit generated values.
-## They also expose a consistent error-reporting interface so the calling code
-## can surface actionable feedback to designers or telemetry systems.
-extends Resource
-class_name GeneratorStrategy
-
-## Emitted whenever the strategy cannot produce a result due to configuration or
-## data issues.  ``code`` identifies the error while ``message`` contains a
-## user-facing explanation.  ``details`` can include extra structured context.
-signal generation_error(code: String, message: String, details: Dictionary)
-
-## Strategies override this method to produce output.  The default
-## implementation simply returns an empty string so subclasses are not forced to
-## call ``super``.
-func generate(config: Dictionary) -> String:
-    return ""
-
-## Helper for subclasses that need to emit configurable errors.  The
-## configuration dictionary can provide a nested ``errors`` dictionary where
-## keys correspond to the error ``code`` value.  When the key is absent the
-## ``default_message`` parameter is used instead.
-func emit_configured_error(config: Dictionary, code: String, default_message: String, details: Dictionary = {}) -> void:
-    var message := default_message
-    if config.has("errors"):
-        var overrides := config.get("errors")
-        if typeof(overrides) == TYPE_DICTIONARY:
-            message = overrides.get(code, default_message)
-
-    emit_signal("generation_error", code, message, details)
-
 extends RefCounted
 class_name GeneratorStrategy
 
-## Base class for all runtime name generation strategies.
-##
-## Strategies receive a configuration [Dictionary] along with a shared
-## [RandomNumberGenerator] when [method generate] is invoked. Subclasses are
-## expected to validate the configuration before use. To make this
-## predictable for integrators, each strategy should override
-## [method _get_expected_config_keys] and list the configuration keys they
-## consume.
-##
-## The expected structure returned by [method _get_expected_config_keys]:
-## ```gdscript
-## return {
-##     "required": PackedStringArray(["culture", "min_length"]),
-##     "optional": {
-##         "max_length": TYPE_INT,
-##         "syllable_bias": TYPE_FLOAT,
-##     }
-## }
-## ```
-## * `required` — keys that must appear in the config dictionary. They may be
-##   provided as either an [Array] of [String] values or a [PackedStringArray].
-## * `optional` — a [Dictionary] that maps key names to expected Godot variant
-##   types (as returned by [method typeof]).
-##
-## When the configuration does not satisfy the declared contract, helper
-## methods in this class produce instances of [GeneratorError] that describe
-## the problem. Strategies may forward these errors to calling code to deliver
-## consistent diagnostics.
+## Emitted when a strategy cannot generate a result.
+signal generation_error(code: String, message: String, details: Dictionary)
+
+## Lightweight error container returned by strategies when generation fails.
 class GeneratorError:
     extends RefCounted
 
-    ## Short machine readable code for the error (e.g. "missing_required_keys").
     var code: String
-
-    ## Human readable summary of what went wrong.
     var message: String
-
-    ## Additional contextual data that helps diagnose the issue.
     var details: Dictionary
 
     func _init(code: String, message: String, details: Dictionary = {}):
@@ -86,67 +24,81 @@ class GeneratorError:
             "details": details.duplicate(true),
         }
 
-func generate(config: Dictionary, rng: RandomNumberGenerator) -> String:
-    assert(false, "GeneratorStrategy.generate is abstract and must be overridden.")
+func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
+    push_error("GeneratorStrategy.generate must be implemented by subclasses.")
     return ""
 
-## Helper to create consistent error payloads.
 func _make_error(code: String, message: String, details: Dictionary = {}) -> GeneratorError:
     return GeneratorError.new(code, message, details)
 
-## Ensures that the provided config is a dictionary.
-func _ensure_dictionary(config: Variant, context: String = "config") -> GeneratorError:
-    if typeof(config) != TYPE_DICTIONARY:
+func _ensure_dictionary(value: Variant, context: String = "config") -> GeneratorError:
+    if typeof(value) != TYPE_DICTIONARY:
         return _make_error(
             "invalid_config_type",
             "%s must be provided as a Dictionary." % context,
             {
-                "received_type": typeof(config),
-                "type_name": Variant.get_type_name(typeof(config)),
+                "received_type": typeof(value),
+                "type_name": Variant.get_type_name(typeof(value)),
             },
         )
     return null
 
-## Validates that every required key declared in [_get_expected_config_keys] exists.
+func _validate_config(config: Variant) -> GeneratorError:
+    var type_error := _ensure_dictionary(config)
+    if type_error:
+        return type_error
+
+    var dictionary: Dictionary = config
+
+    var required_error := _validate_required_keys(dictionary)
+    if required_error:
+        return required_error
+
+    var optional_error := _validate_optional_key_types(dictionary)
+    if optional_error:
+        return optional_error
+
+    return null
+
 func _validate_required_keys(config: Dictionary) -> GeneratorError:
-    var expected := _get_expected_config_keys()
-    if expected.is_empty() or not expected.has("required"):
+    var expectations := _get_expected_config_keys()
+    if expectations.is_empty() or not expectations.has("required"):
         return null
 
-    var required_keys = expected["required"]
-    var normalized_required := PackedStringArray()
+    var required_keys := expectations["required"]
+    var normalized := PackedStringArray()
     if required_keys is PackedStringArray:
-        normalized_required = required_keys
+        normalized = required_keys
     else:
         for key in required_keys:
-            normalized_required.append(String(key))
+            normalized.append(String(key))
 
     var missing := PackedStringArray()
-    for key in normalized_required:
+    for key in normalized:
         if not config.has(key):
             missing.append(key)
 
-    if not missing.is_empty():
-        return _make_error(
-            "missing_required_keys",
-            "Configuration is missing required keys: %s." % ", ".join(missing),
-            {"missing": missing},
-        )
-    return null
-
-## Validates optional key types declared in [_get_expected_config_keys].
-func _validate_optional_key_types(config: Dictionary) -> GeneratorError:
-    var expected := _get_expected_config_keys()
-    if expected.is_empty() or not expected.has("optional"):
+    if missing.is_empty():
         return null
 
-    var optional: Dictionary = expected["optional"]
+    return _make_error(
+        "missing_required_keys",
+        "Configuration is missing required keys: %s." % ", ".join(missing),
+        {"missing": missing},
+    )
+
+func _validate_optional_key_types(config: Dictionary) -> GeneratorError:
+    var expectations := _get_expected_config_keys()
+    if expectations.is_empty() or not expectations.has("optional"):
+        return null
+
+    var optional: Dictionary = expectations["optional"]
     for key in optional.keys():
         if not config.has(key):
             continue
 
         var expected_type: int = optional[key]
-        var value = config[key]
+        var value := config[key]
         if typeof(value) != expected_type:
             return _make_error(
                 "invalid_key_type",
@@ -159,30 +111,27 @@ func _validate_optional_key_types(config: Dictionary) -> GeneratorError:
                     "received_type_name": Variant.get_type_name(typeof(value)),
                 },
             )
-    return null
-
-## Combined validation helper that strategies can call in their generate methods.
-func _validate_config(config: Variant) -> GeneratorError:
-    var error := _ensure_dictionary(config)
-    if error:
-        return error
-
-    var dict_config: Dictionary = config
-
-    error = _validate_required_keys(dict_config)
-    if error:
-        return error
-
-    error = _validate_optional_key_types(dict_config)
-    if error:
-        return error
 
     return null
 
-## Subclasses may override to advertise their configuration contract.
+func emit_configured_error(
+    config: Dictionary,
+    code: String,
+    default_message: String,
+    details: Dictionary = {}
+) -> GeneratorError:
+    var message := default_message
+    if config.has("errors"):
+        var overrides := config.get("errors")
+        if typeof(overrides) == TYPE_DICTIONARY and overrides.has(code):
+            message = String(overrides[code])
+
+    var error := _make_error(code, message, details)
+    emit_signal("generation_error", error.code, error.message, error.details)
+    return error
+
 func _get_expected_config_keys() -> Dictionary:
     return {
         "required": PackedStringArray(),
         "optional": {},
     }
-

--- a/name_generator/strategies/HybridStrategy.gd
+++ b/name_generator/strategies/HybridStrategy.gd
@@ -1,0 +1,176 @@
+extends GeneratorStrategy
+class_name HybridStrategy
+
+const NameGenerator := preload("res://name_generator/NameGenerator.gd")
+const RNGStreamRouter := preload("res://name_generator/utils/RNGManager.gd")
+
+const PLACEHOLDER_PATTERN := "\\$([A-Za-z0-9_]+)"
+
+var _placeholder_regex: RegEx
+
+func _get_expected_config_keys() -> Dictionary:
+    return {
+        "required": PackedStringArray(["steps"]),
+        "optional": {
+            "template": TYPE_STRING,
+            "seed": TYPE_STRING,
+        },
+    }
+
+func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
+    var validation_error := _validate_config(config)
+    if validation_error:
+        return validation_error
+
+    var steps_variant := config.get("steps")
+    if not (steps_variant is Array):
+        return _make_error(
+            "invalid_steps_type",
+            "HybridStrategy expects 'steps' to be an Array of configuration dictionaries.",
+            {
+                "received_type": typeof(steps_variant),
+                "type_name": Variant.get_type_name(typeof(steps_variant)),
+            },
+        )
+
+    var steps: Array = steps_variant
+    if steps.is_empty():
+        return _make_error(
+            "empty_steps",
+            "HybridStrategy requires at least one step configuration.",
+        )
+
+    var rng_router := RNGStreamRouter.new(rng)
+    var results: Array[String] = []
+    var placeholders := {}
+    var parent_seed := String(config.get("seed", ""))
+
+    for index in range(steps.size()):
+        var entry_variant := steps[index]
+        if typeof(entry_variant) != TYPE_DICTIONARY:
+            return _make_error(
+                "invalid_step_entry",
+                "HybridStrategy steps must contain Dictionary entries.",
+                {
+                    "index": index,
+                    "entry_type": typeof(entry_variant),
+                },
+            )
+
+        var entry: Dictionary = (entry_variant as Dictionary).duplicate(true)
+        var alias := String(entry.get("store_as", String(index))).strip_edges()
+        entry.erase("store_as")
+
+        var step_config := _extract_step_config(entry)
+        if step_config is GeneratorError:
+            return step_config
+
+        step_config = _substitute_variant(step_config, placeholders)
+
+        if not step_config.has("seed"):
+            step_config["seed"] = "%s::step_%s" % [parent_seed, alias]
+
+        var child_rng := rng_router.derive_rng([alias, String(index)])
+        var result := NameGenerator.generate(step_config, child_rng)
+        if result is Dictionary and result.has("code"):
+            return _make_error(
+                String(result.get("code", "hybrid_step_error")),
+                "Hybrid step %s failed to generate." % alias,
+                {
+                    "index": index,
+                    "alias": alias,
+                    "details": result.get("details", {}),
+                    "message": result.get("message", ""),
+                },
+            )
+
+        var result_string := String(result)
+        results.append(result_string)
+        placeholders[String(index)] = result_string
+        if not alias.is_empty():
+            placeholders[alias] = result_string
+    
+    if config.has("template"):
+        var template_string := String(config["template"])
+        return _replace_placeholders(template_string, placeholders)
+
+    return results.back()
+
+func _extract_step_config(entry: Dictionary) -> Variant:
+    if entry.has("config"):
+        var payload := entry["config"]
+        if typeof(payload) != TYPE_DICTIONARY:
+            return _make_error(
+                "invalid_step_config",
+                "Hybrid step 'config' must be a Dictionary.",
+                {
+                    "received_type": typeof(payload),
+                    "type_name": Variant.get_type_name(typeof(payload)),
+                },
+            )
+        return (payload as Dictionary).duplicate(true)
+
+    if not entry.has("strategy"):
+        return _make_error(
+            "missing_step_strategy",
+            "Each hybrid step must define a 'strategy'.",
+        )
+
+    return entry.duplicate(true)
+
+func _substitute_variant(value: Variant, placeholders: Dictionary) -> Variant:
+    match typeof(value):
+        TYPE_STRING:
+            return _replace_placeholders(String(value), placeholders)
+        TYPE_DICTIONARY:
+            var clone := {}
+            var dictionary: Dictionary = value
+            for key in dictionary.keys():
+                clone[key] = _substitute_variant(dictionary[key], placeholders)
+            return clone
+        TYPE_ARRAY:
+            var array_value: Array = value
+            var clone_array := []
+            for element in array_value:
+                clone_array.append(_substitute_variant(element, placeholders))
+            return clone_array
+        TYPE_PACKED_STRING_ARRAY:
+            var packed: PackedStringArray = value
+            var new_array := PackedStringArray()
+            for element in packed:
+                new_array.append(_replace_placeholders(element, placeholders))
+            return new_array
+        _:
+            return value
+
+func _replace_placeholders(text: String, placeholders: Dictionary) -> String:
+    var regex := _get_placeholder_regex()
+    var matches := regex.search_all(text)
+    if matches.is_empty():
+        return text
+
+    var result := ""
+    var cursor := 0
+    for match in matches:
+        var start_index := match.get_start()
+        var end_index := match.get_end()
+        result += text.substr(cursor, start_index - cursor)
+
+        var key := match.get_string(1)
+        if placeholders.has(key):
+            result += String(placeholders[key])
+        else:
+            result += text.substr(start_index, end_index - start_index)
+
+        cursor = end_index
+
+    result += text.substr(cursor)
+    return result
+
+func _get_placeholder_regex() -> RegEx:
+    if _placeholder_regex == null:
+        _placeholder_regex = RegEx.new()
+        var error := _placeholder_regex.compile(PLACEHOLDER_PATTERN)
+        if error != OK:
+            push_error("Failed to compile hybrid placeholder regex: %s" % PLACEHOLDER_PATTERN)
+    return _placeholder_regex

--- a/name_generator/strategies/SyllableChainStrategy.gd
+++ b/name_generator/strategies/SyllableChainStrategy.gd
@@ -234,7 +234,7 @@ func _pick_from_packed_strings(values: PackedStringArray, rng: RandomNumberGener
     if as_array.is_empty():
         return ""
 
-    return String(ArrayUtils.pick_random_deterministic(as_array, rng))
+    return String(ArrayUtils.pick_uniform(as_array, rng))
 
 func _join_with_smoothing(fragments: Array) -> String:
     var result := ""

--- a/name_generator/strategies/TemplateStrategy.gd
+++ b/name_generator/strategies/TemplateStrategy.gd
@@ -1,46 +1,56 @@
 extends GeneratorStrategy
 class_name TemplateStrategy
 
+const NameGenerator := preload("res://name_generator/NameGenerator.gd")
+const RNGStreamRouter := preload("res://name_generator/utils/RNGManager.gd")
 
-## TemplateStrategy stitches together nested generator outputs based on a
-## configurable template string.
-##
-## Tokens wrapped in square brackets (e.g. ``[title]``) are replaced by invoking
-## child generator configurations declared in ``config.sub_generators``. Each
-## token receives its own deterministic ``RandomNumberGenerator`` derived from
-## the parent stream through ``RNGManager`` so repeated evaluations remain
-## reproducible across runs.
 const TOKEN_PATTERN := "\\[(?<token>[^\\[\\]]+)\\]"
-const DEFAULT_MAX_DEPTH := 8
 const INTERNAL_DEPTH_KEY := "__template_depth"
 const INTERNAL_MAX_DEPTH_KEY := "__template_max_depth"
+const DEFAULT_MAX_DEPTH := 8
 
-static var _token_regex: RegEx
+var _token_regex: RegEx
+
+func _get_expected_config_keys() -> Dictionary:
+    return {
+        "required": PackedStringArray(["template_string"]),
+        "optional": {
+            "sub_generators": TYPE_DICTIONARY,
+            "max_depth": TYPE_INT,
+            "seed": TYPE_STRING,
+        },
+    }
 
 func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
     var validation_error := _validate_config(config)
     if validation_error:
         return validation_error
 
-    if typeof(config["template_string"]) != TYPE_STRING:
+    var template_value := config.get("template_string", "")
+    if typeof(template_value) != TYPE_STRING:
         return _make_error(
-            "invalid_key_type",
-            "Configuration value for 'template_string' must be of type String.",
+            "invalid_template_type",
+            "TemplateStrategy requires 'template_string' to be a String.",
             {
-                "key": "template_string",
-                "expected_type": TYPE_STRING,
-                "expected_type_name": Variant.get_type_name(TYPE_STRING),
-                "received_type": typeof(config["template_string"]),
-                "received_type_name": Variant.get_type_name(typeof(config["template_string"])),
+                "received_type": typeof(template_value),
+                "type_name": Variant.get_type_name(typeof(template_value)),
             },
         )
 
-    var template_string := String(config["template_string"])
+    var template_string := String(template_value)
     var sub_generators: Dictionary = {}
     if config.has("sub_generators"):
-        sub_generators = config["sub_generators"]
+        if typeof(config["sub_generators"]) != TYPE_DICTIONARY:
+            return _make_error(
+                "invalid_sub_generators_type",
+                "TemplateStrategy optional 'sub_generators' must be a Dictionary.",
+                {
+                    "received_type": typeof(config["sub_generators"]),
+                    "type_name": Variant.get_type_name(typeof(config["sub_generators"])),
+                },
+            )
+        sub_generators = (config["sub_generators"] as Dictionary).duplicate(true)
 
-    var current_depth := int(config.get(INTERNAL_DEPTH_KEY, 0))
     var max_depth := _resolve_max_depth(config)
     if max_depth <= 0:
         return _make_error(
@@ -49,6 +59,7 @@ func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
             {"max_depth": max_depth},
         )
 
+    var current_depth := int(config.get(INTERNAL_DEPTH_KEY, 0))
     if current_depth >= max_depth:
         return _make_error(
             "template_recursion_depth_exceeded",
@@ -64,10 +75,11 @@ func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
     if matches.is_empty():
         return template_string
 
-    var rng_manager := RNGManager.new(rng)
+    var rng_router := RNGStreamRouter.new(rng)
     var token_counts := {}
     var cursor := 0
     var expanded := ""
+    var parent_seed := String(config.get("seed", ""))
 
     for match in matches:
         var start_index := match.get_start()
@@ -76,16 +88,22 @@ func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
 
         var token := _extract_token(match)
         token = token.strip_edges()
-        var occurrence := 0
-        if token_counts.has(token):
-            occurrence = int(token_counts[token])
+        if token.is_empty():
+            return _make_error(
+                "empty_token",
+                "Template token at index %d must specify a sub-generator key." % start_index,
+                {"start_index": start_index},
+            )
+
+        var occurrence := int(token_counts.get(token, 0))
         token_counts[token] = occurrence + 1
 
         var replacement := _resolve_token(
             token,
             occurrence,
             sub_generators,
-            rng_manager,
+            rng_router,
+            parent_seed,
             current_depth,
             max_depth,
         )
@@ -99,17 +117,6 @@ func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
 
     return expanded
 
-
-func _get_expected_config_keys() -> Dictionary:
-    return {
-        "required": PackedStringArray(["template_string"]),
-        "optional": {
-            "sub_generators": TYPE_DICTIONARY,
-            "max_depth": TYPE_INT,
-        },
-    }
-
-
 func _resolve_max_depth(config: Dictionary) -> int:
     if config.has("max_depth"):
         return int(config["max_depth"])
@@ -117,37 +124,24 @@ func _resolve_max_depth(config: Dictionary) -> int:
         return int(config[INTERNAL_MAX_DEPTH_KEY])
     return DEFAULT_MAX_DEPTH
 
-
 func _extract_token(match: RegExMatch) -> String:
     if match.names.has("token"):
         return match.get_string("token")
     return match.get_string(1)
 
-
 func _resolve_token(
     token: String,
     occurrence: int,
     sub_generators: Dictionary,
-    rng_manager: RNGManager,
+    rng_router: RNGStreamRouter,
+    parent_seed: String,
     current_depth: int,
-    max_depth: int,
+    max_depth: int
 ) -> Variant:
-    if current_depth + 1 > max_depth:
-        return _make_error(
-            "template_recursion_depth_exceeded",
-            "Template expansion exceeded the allowed recursion depth while resolving '%s'." % token,
-            {
-                "token": token,
-                "max_depth": max_depth,
-                "current_depth": current_depth,
-            },
-        )
-
     if not sub_generators.has(token):
         var available := PackedStringArray()
         for key in sub_generators.keys():
             available.append(String(key))
-
         return _make_error(
             "missing_template_token",
             "Template token '%s' does not have a configured sub-generator." % token,
@@ -167,266 +161,24 @@ func _resolve_token(
     if not generator_config.has("max_depth") and not generator_config.has(INTERNAL_MAX_DEPTH_KEY):
         generator_config[INTERNAL_MAX_DEPTH_KEY] = max_depth
 
-    var path := [token, String(occurrence), String(current_depth + 1)]
-    var child_rng := rng_manager.derive_rng(path)
+    if not generator_config.has("seed"):
+        generator_config["seed"] = "%s::%s::%d" % [parent_seed, token, occurrence]
 
-    var result := _invoke_name_generator(generator_config, child_rng)
-    if result is GeneratorError:
-        return result
-
-    return String(result)
-
-
-func _invoke_name_generator(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
-    var callable := _resolve_name_generator_callable()
-    if callable.is_null():
+    var child_rng := rng_router.derive_rng([token, String(occurrence), String(current_depth + 1)])
+    var result := NameGenerator.generate(generator_config, child_rng)
+    if result is Dictionary and result.has("code"):
         return _make_error(
-            "missing_name_generator",
-            "NameGenerator.generate callable could not be resolved.",
-            {
-                "config": config,
-            },
+            String(result.get("code", "template_child_error")),
+            String(result.get("message", "Template sub-generator failed.")),
+            result.get("details", {}),
         )
 
-    return callable.call(config, rng)
+    return result
 
-
-func _resolve_name_generator_callable() -> Callable:
-    if Engine.has_singleton("NameGenerator"):
-        var singleton := Engine.get_singleton("NameGenerator")
-        if singleton != null and singleton.has_method("generate"):
-            return Callable(singleton, "generate")
-
-    if ResourceLoader.exists("res://name_generator/NameGenerator.gd"):
-        var script := load("res://name_generator/NameGenerator.gd")
-        if script != null:
-            if script.has_method("generate"):
-                return Callable(script, "generate")
-            if script.can_instantiate():
-                var instance := script.instantiate()
-                if instance != null and instance.has_method("generate"):
-                    return Callable(instance, "generate")
-
-    return Callable()
-
-
-static func _get_token_regex() -> RegEx:
+func _get_token_regex() -> RegEx:
     if _token_regex == null:
         _token_regex = RegEx.new()
         var error := _token_regex.compile(TOKEN_PATTERN)
         if error != OK:
             push_error("Failed to compile template token pattern: %s" % TOKEN_PATTERN)
     return _token_regex
-
-const NameGenerator = preload("res://name_generator/NameGenerator.gd")
-const RNGManager = preload("res://name_generator/utils/RNGManager.gd")
-
-const INTERNAL_DEPTH_KEY := "__template_depth"
-const INTERNAL_LINEAGE_KEY := "__template_lineage"
-const DEFAULT_MAX_DEPTH := 10
-
-## Default token pattern strips the surrounding brackets and any whitespace.
-const _TOKEN_START := "["
-const _TOKEN_END := "]"
-
-func _get_expected_config_keys() -> Dictionary:
-    return {
-        "required": PackedStringArray(["template_string"]),
-        "optional": {
-            "sub_generators": TYPE_DICTIONARY,
-            "max_depth": TYPE_INT,
-        },
-    }
-
-func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
-    var error := _validate_config(config)
-    if error:
-        return error
-
-    if rng == null:
-        rng = RandomNumberGenerator.new()
-
-    var template_string = config.get("template_string", "")
-    if typeof(template_string) != TYPE_STRING:
-        return _make_error(
-            "invalid_template_type",
-            "TemplateStrategy requires 'template_string' to be a String.",
-            {
-                "received_type": typeof(template_string),
-                "type_name": Variant.get_type_name(typeof(template_string)),
-            },
-        )
-
-    var sub_generators: Dictionary = {}
-    if config.has("sub_generators"):
-        var provided = config["sub_generators"]
-        if typeof(provided) != TYPE_DICTIONARY:
-            return _make_error(
-                "invalid_sub_generators_type",
-                "TemplateStrategy optional 'sub_generators' must be a Dictionary.",
-                {
-                    "received_type": typeof(provided),
-                    "type_name": Variant.get_type_name(typeof(provided)),
-                },
-            )
-        sub_generators = (provided as Dictionary).duplicate(true)
-
-    var max_depth := DEFAULT_MAX_DEPTH
-    if config.has("max_depth"):
-        var provided_max_depth = config["max_depth"]
-        if typeof(provided_max_depth) != TYPE_INT:
-            return _make_error(
-                "invalid_max_depth_type",
-                "TemplateStrategy optional 'max_depth' must be an int.",
-                {
-                    "received_type": typeof(provided_max_depth),
-                    "type_name": Variant.get_type_name(typeof(provided_max_depth)),
-                },
-            )
-        max_depth = int(provided_max_depth)
-        if max_depth <= 0:
-            return _make_error(
-                "invalid_max_depth_value",
-                "TemplateStrategy 'max_depth' must be greater than zero.",
-                {"max_depth": max_depth},
-            )
-
-    var current_depth := int(config.get(INTERNAL_DEPTH_KEY, 0))
-    var lineage: Array = []
-    if config.has(INTERNAL_LINEAGE_KEY):
-        var provided_lineage = config[INTERNAL_LINEAGE_KEY]
-        if provided_lineage is Array:
-            lineage = (provided_lineage as Array).duplicate(true)
-
-    if current_depth >= max_depth:
-        return _make_error(
-            "max_depth_exceeded",
-            "TemplateStrategy exceeded the maximum recursion depth of %d." % max_depth,
-            {
-                "max_depth": max_depth,
-                "lineage": lineage.duplicate(true),
-            },
-        )
-
-    return _render_template(
-        String(template_string),
-        sub_generators,
-        rng,
-        current_depth,
-        max_depth,
-        lineage,
-    )
-
-func _render_template(
-    template_string: String,
-    sub_generators: Dictionary,
-    rng: RandomNumberGenerator,
-    current_depth: int,
-    max_depth: int,
-    lineage: Array,
-) -> Variant:
-    var token_rngs: Dictionary = {}
-    var result := ""
-    var index := 0
-
-    while index < template_string.length():
-        var next_token_start := template_string.find(_TOKEN_START, index)
-        if next_token_start == -1:
-            result += template_string.substr(index, template_string.length() - index)
-            break
-
-        result += template_string.substr(index, next_token_start - index)
-        var token_close := template_string.find(_TOKEN_END, next_token_start + 1)
-        if token_close == -1:
-            return _make_error(
-                "unclosed_token",
-                "Template token starting at index %d is missing a closing ']'." % next_token_start,
-                {"start_index": next_token_start},
-            )
-
-        var token_key := template_string.substr(next_token_start + 1, token_close - next_token_start - 1).strip_edges()
-        if token_key.is_empty():
-            return _make_error(
-                "empty_token",
-                "Template token at index %d must specify a sub-generator key." % next_token_start,
-                {"start_index": next_token_start},
-            )
-
-        var token_value := _resolve_token(
-            token_key,
-            sub_generators,
-            rng,
-            token_rngs,
-            current_depth,
-            max_depth,
-            lineage,
-        )
-        if token_value is GeneratorStrategy.GeneratorError:
-            return token_value
-
-        result += String(token_value)
-        index = token_close + 1
-
-    return result
-
-func _resolve_token(
-    token_key: String,
-    sub_generators: Dictionary,
-    parent_rng: RandomNumberGenerator,
-    token_rngs: Dictionary,
-    current_depth: int,
-    max_depth: int,
-    lineage: Array,
-) -> Variant:
-    if not sub_generators.has(token_key):
-        return _make_error(
-            "missing_sub_generator",
-            "Template references unknown token '%s'." % token_key,
-            {
-                "token": token_key,
-                "available_tokens": sub_generators.keys(),
-            },
-        )
-
-    var token_config_variant = sub_generators[token_key]
-    if typeof(token_config_variant) != TYPE_DICTIONARY:
-        return _make_error(
-            "invalid_sub_generator_config",
-            "Configuration for token '%s' must be a Dictionary." % token_key,
-            {
-                "token": token_key,
-                "received_type": typeof(token_config_variant),
-                "type_name": Variant.get_type_name(typeof(token_config_variant)),
-            },
-        )
-
-    var token_config: Dictionary = (token_config_variant as Dictionary).duplicate(true)
-    token_config[INTERNAL_DEPTH_KEY] = current_depth + 1
-    if not token_config.has("max_depth"):
-        token_config["max_depth"] = max_depth
-    var updated_lineage := lineage.duplicate(true)
-    updated_lineage.append(token_key)
-    token_config[INTERNAL_LINEAGE_KEY] = updated_lineage
-
-    var token_rng: RandomNumberGenerator = token_rngs.get(token_key, null)
-    if token_rng == null:
-        token_rng = RNGManager.derive_child_rng(parent_rng, token_key, current_depth)
-        token_rngs[token_key] = token_rng
-
-    var generated_value := NameGenerator.generate(token_config, token_rng)
-    if generated_value is GeneratorStrategy.GeneratorError:
-        return generated_value
-
-    if typeof(generated_value) != TYPE_STRING:
-        return _make_error(
-            "invalid_generated_type",
-            "Generated value for token '%s' must be a String." % token_key,
-            {
-                "token": token_key,
-                "received_type": typeof(generated_value),
-                "type_name": Variant.get_type_name(typeof(generated_value)),
-            },
-        )
-
-    return generated_value
-

--- a/name_generator/strategies/WordlistStrategy.gd
+++ b/name_generator/strategies/WordlistStrategy.gd
@@ -1,14 +1,8 @@
-## Strategy that assembles a name by sampling entries from authored word lists.
-##
-## The configuration dictionary supports the following keys:
-## - ``wordlist_paths``: Array of resource paths to [WordListResource] assets.
-## - ``use_weights``: Optional boolean flag that enables weighted selection when
-##   a list provides weight data.
-## - ``delimiter``: Optional string used to join the selected entries.  Defaults
-##   to a single space.
-## - ``errors``: Optional dictionary mapping error codes to custom messages.
 extends GeneratorStrategy
 class_name WordlistStrategy
+
+const WordListResource := preload("res://name_generator/resources/WordListResource.gd")
+const ArrayUtils := preload("res://name_generator/utils/ArrayUtils.gd")
 
 const ERROR_NO_PATHS := "wordlists_missing"
 const ERROR_LOAD_FAILED := "wordlist_load_failed"
@@ -16,69 +10,138 @@ const ERROR_INVALID_RESOURCE := "wordlist_invalid_type"
 const ERROR_EMPTY_RESOURCE := "wordlist_empty"
 const ERROR_NO_SELECTION := "wordlists_no_selection"
 
-func generate(config: Dictionary) -> String:
-    var wordlist_paths := _normalize_paths(config.get("wordlist_paths", []))
-    if wordlist_paths.is_empty():
-        emit_configured_error(config, ERROR_NO_PATHS, "No word list resources were provided.")
-        return ""
-
-    var delimiter: String = config.get("delimiter", " ")
-    var use_weights: bool = config.get("use_weights", false)
-    var selections: Array[String] = []
-
-    for path in wordlist_paths:
-        var data := _load_wordlist(path, config)
-        if data.is_empty():
-            continue
-
-        var entries: Array = data.get("entries", [])
-        var weights: Array = data.get("weights", [])
-        var selection := _select_entry(entries, weights, use_weights)
-        if selection == null:
-            continue
-        selections.append(str(selection))
-
-    if selections.is_empty():
-        emit_configured_error(config, ERROR_NO_SELECTION, "No entries were available from the configured word lists.")
-        return ""
-
-    return selections.join(delimiter)
-
-func _normalize_paths(raw_paths: Variant) -> Array[String]:
-    var normalized: Array[String] = []
-    if raw_paths is PackedStringArray:
-        raw_paths = raw_paths.to_array()
-    if raw_paths is Array:
-        for path in raw_paths:
-            if typeof(path) == TYPE_STRING and not String(path).is_empty():
-                normalized.append(path)
-    return normalized
-
-func _load_wordlist(path: String, config: Dictionary) -> Dictionary:
-    var resource := ResourceLoader.load(path)
-    if resource == null:
-        emit_configured_error(config, ERROR_LOAD_FAILED, "Failed to load word list resource at '%s'." % path, {"path": path})
-        return {}
-
-    if not resource is WordListResource:
-        emit_configured_error(config, ERROR_INVALID_RESOURCE, "Resource at '%s' is not a WordListResource." % path, {"path": path})
-        return {}
-
-    var entries := resource.get_entries()
-    if entries.is_empty():
-        emit_configured_error(config, ERROR_EMPTY_RESOURCE, "Word list '%s' does not contain any entries." % path, {"path": path})
-        return {}
-
+func _get_expected_config_keys() -> Dictionary:
     return {
-        "entries": entries,
-        "weights": resource.get_weights(),
+        "required": PackedStringArray(["wordlist_paths"]),
+        "optional": {
+            "delimiter": TYPE_STRING,
+            "use_weights": TYPE_BOOL,
+        },
     }
 
-func _select_entry(entries: Array, weights: Array, use_weights: bool) -> Variant:
+func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
+    var validation_error := _validate_config(config)
+    if validation_error:
+        return validation_error
+
+    var resources_result := _collect_resources(config["wordlist_paths"])
+    if resources_result is GeneratorError:
+        return resources_result
+
+    var resources: Array = resources_result
+    if resources.is_empty():
+        return emit_configured_error(
+            config,
+            ERROR_NO_PATHS,
+            "No word list resources were provided.",
+        )
+
+    var selections: Array[String] = []
+    var use_weights := bool(config.get("use_weights", false))
+    var delimiter := String(config.get("delimiter", " "))
+
+    for resource in resources:
+        var picked := _pick_from_resource(resource, use_weights, rng, config)
+        if picked is GeneratorError:
+            return picked
+        if picked == null:
+            continue
+        selections.append(String(picked))
+
+    if selections.is_empty():
+        return emit_configured_error(
+            config,
+            ERROR_NO_SELECTION,
+            "No entries were available from the configured word lists.",
+        )
+
+    return delimiter.join(selections)
+
+func _collect_resources(sources: Variant) -> Variant:
+    var normalized := []
+    var entries := []
+
+    if sources is PackedStringArray:
+        entries = sources.to_array()
+    elif sources is Array:
+        entries = sources
+    else:
+        return _make_error(
+            "invalid_wordlist_paths_type",
+            "'wordlist_paths' must be an Array of resource paths or WordListResource instances.",
+            {"received_type": typeof(sources)},
+        )
+
+    for entry in entries:
+        if entry is WordListResource:
+            normalized.append(entry)
+            continue
+
+        if typeof(entry) != TYPE_STRING:
+            return _make_error(
+                "invalid_wordlist_entry",
+                "Entries in 'wordlist_paths' must be strings or WordListResource instances.",
+                {
+                    "entry": entry,
+                    "entry_type": typeof(entry),
+                },
+            )
+
+        var path := String(entry).strip_edges()
+        if path.is_empty():
+            continue
+
+        if not ResourceLoader.exists(path):
+            return _make_error(
+                ERROR_LOAD_FAILED,
+                "Word list resource could not be found at '%s'." % path,
+                {"path": path},
+            )
+
+        var resource := ResourceLoader.load(path)
+        if resource == null:
+            return _make_error(
+                ERROR_LOAD_FAILED,
+                "Failed to load word list resource at '%s'." % path,
+                {"path": path},
+            )
+
+        if not (resource is WordListResource):
+            return _make_error(
+                ERROR_INVALID_RESOURCE,
+                "Resource at '%s' must be a WordListResource." % path,
+                {
+                    "path": path,
+                    "received_type": resource.get_class(),
+                },
+            )
+
+        normalized.append(resource)
+
+    return normalized
+
+func _pick_from_resource(
+    resource: WordListResource,
+    use_weights: bool,
+    rng: RandomNumberGenerator,
+    config: Dictionary
+) -> Variant:
+    if use_weights and resource.has_weight_data():
+        var weighted_entries := resource.get_weighted_entries()
+        if weighted_entries.is_empty():
+            return emit_configured_error(
+                config,
+                ERROR_EMPTY_RESOURCE,
+                "Word list resource is empty.",
+            )
+        return ArrayUtils.pick_weighted(weighted_entries, rng)
+
+    var entries := resource.get_uniform_entries()
     if entries.is_empty():
-        return null
+        return emit_configured_error(
+            config,
+            ERROR_EMPTY_RESOURCE,
+            "Word list resource is empty.",
+        )
 
-    if use_weights and not weights.is_empty():
-        return ArrayUtils.pick_weighted(entries, weights)
-
-    return ArrayUtils.pick_uniform(entries)
+    return ArrayUtils.pick_uniform(entries, rng)

--- a/name_generator/tests/test_generator_strategy.gd
+++ b/name_generator/tests/test_generator_strategy.gd
@@ -26,7 +26,7 @@ class MockStrategy:
         for value in config["values"]:
             normalized.append(String(value))
 
-        var selected: String = ArrayUtils.pick_random_deterministic(normalized, rng)
+        var selected: String = ArrayUtils.pick_uniform(normalized, rng)
 
         if config.get("uppercase", false):
             selected = selected.to_upper()

--- a/name_generator/tests/test_hybrid_strategy.gd
+++ b/name_generator/tests/test_hybrid_strategy.gd
@@ -1,0 +1,131 @@
+extends RefCounted
+
+const HybridStrategy := preload("res://name_generator/strategies/HybridStrategy.gd")
+const GeneratorStrategy := preload("res://name_generator/strategies/GeneratorStrategy.gd")
+
+const WORDLIST_PATH := "res://tests/test_assets/wordlist_basic.tres"
+const SYLLABLE_PATH := "res://tests/test_assets/syllable_basic.tres"
+const MARKOV_PATH := "res://tests/test_assets/markov_basic.tres"
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+    _run_test("hybrid_generates_expected_structure", func(): _test_hybrid_structure())
+    _run_test("hybrid_generation_is_deterministic", func(): _test_determinism())
+
+    return {
+        "suite": "HybridStrategy",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+        return
+
+    _failed += 1
+    _failures.append({
+        "name": name,
+        "message": String(message),
+    })
+
+func _test_hybrid_structure() -> Variant:
+    var strategy := HybridStrategy.new()
+    var rng := RandomNumberGenerator.new()
+    rng.seed = 12345
+
+    var config := _make_config()
+    var result := strategy.generate(config, rng)
+
+    if result is GeneratorStrategy.GeneratorError:
+        return "HybridStrategy returned error: %s" % result.message
+
+    var text := String(result)
+    if text.find("$") != -1:
+        return "Template placeholders must be replaced in the final output."
+
+    var parts := text.split(" ", false)
+    if parts.size() < 2:
+        return "Hybrid output should contain a space between title and name."
+
+    var title := parts[0]
+    var body := parts[1]
+
+    var allowed_titles := ["Brave", "Mighty", "Shadow"]
+    if not allowed_titles.has(title):
+        return "Title component must originate from the word list resource."
+
+    if body.length() < 3:
+        return "Generated body component must contain at least three characters."
+
+    return null
+
+func _test_determinism() -> Variant:
+    var strategy := HybridStrategy.new()
+    var first_rng := RandomNumberGenerator.new()
+    first_rng.seed = 2024
+    var second_rng := RandomNumberGenerator.new()
+    second_rng.seed = 2024
+
+    var config_one := _make_config()
+    var config_two := _make_config()
+
+    var first := strategy.generate(config_one, first_rng)
+    var second := strategy.generate(config_two, second_rng)
+
+    if first is GeneratorStrategy.GeneratorError:
+        return "First generation failed: %s" % first.message
+    if second is GeneratorStrategy.GeneratorError:
+        return "Second generation failed: %s" % second.message
+
+    if String(first) != String(second):
+        return "Hybrid generation must be deterministic for identical seeds."
+
+    var alternate_rng := RandomNumberGenerator.new()
+    alternate_rng.seed = 99
+    var alternate := strategy.generate(_make_config(), alternate_rng)
+    if alternate is GeneratorStrategy.GeneratorError:
+        return "Alternate generation failed: %s" % alternate.message
+
+    if String(alternate) == String(first):
+        return "Different seeds should yield different hybrid names."
+
+    return null
+
+func _make_config() -> Dictionary:
+    return {
+        "seed": "hybrid_test_seed",
+        "steps": [
+            {
+                "strategy": "wordlist",
+                "wordlist_paths": [WORDLIST_PATH],
+                "use_weights": true,
+                "store_as": "title",
+            },
+            {
+                "strategy": "markov",
+                "markov_model_path": MARKOV_PATH,
+                "store_as": "root",
+            },
+            {
+                "strategy": "syllable",
+                "syllable_set_path": SYLLABLE_PATH,
+                "require_middle": false,
+                "store_as": "suffix",
+            },
+        ],
+        "template": "$title $root$suffix",
+    }

--- a/name_generator/utils/ArrayUtils.gd
+++ b/name_generator/utils/ArrayUtils.gd
@@ -1,47 +1,58 @@
+## Utility helpers for deterministic array selection.
+##
+## The functions in this module intentionally avoid touching Godot's global RNG
+## state. Callers must supply an explicit [RandomNumberGenerator] so reproducible
+## results can be achieved across gameplay, tooling, and automated tests.
 class_name ArrayUtils
 
-"""
-Utility helpers for deterministic array selection.
-
-This module intentionally never reaches out to Godot's global random number
-functions.  Every operation that requires randomness expects a
-``RandomNumberGenerator`` instance to be supplied by the caller so tests and
-save/load flows can provide their own deterministic seeds.
-"""
-
 static func assert_not_empty(collection: Array, context: String = "Collection") -> void:
-    """
-    Ensure that ``collection`` contains at least one element.
-
-    The helpers in this file intentionally avoid any calls to global
-    randomness APIs so the caller has full control over the provided
-    ``RandomNumberGenerator``.
-    """
     if collection == null or collection.is_empty():
         var message := "%s must not be empty." % context
         push_error(message)
         assert(false, message)
 
+static func pick_uniform(items: Array, rng: RandomNumberGenerator) -> Variant:
+    assert_not_empty(items, "Items")
+    if items.size() == 1:
+        return items[0]
+    var index := rng.randi_range(0, items.size() - 1)
+    return items[index]
+
+static func pick_random_deterministic(items: Array, rng: RandomNumberGenerator) -> Variant:
+    return pick_uniform(items, rng)
+
+static func pick_weighted(entries: Array, rng: RandomNumberGenerator) -> Variant:
+    assert_not_empty(entries, "Weighted entries")
+    var normalised := []
+    var total_weight := 0.0
+
+    for entry in entries:
+        var parsed := _parse_weighted_entry(entry)
+        total_weight += parsed["weight"]
+        normalised.append(parsed)
+
+    if total_weight <= 0.0:
+        var message := "Weighted entries must have a combined positive weight."
+        push_error(message)
+        assert(false, message)
+
+    var roll := rng.randf() * total_weight
+    var cumulative := 0.0
+    for entry in normalised:
+        cumulative += entry["weight"]
+        if roll <= cumulative:
+            return entry["value"]
+
+    return normalised.back()["value"]
+
+static func pick_weighted_random_deterministic(entries: Array, rng: RandomNumberGenerator) -> Variant:
+    return pick_weighted(entries, rng)
 
 static func handle_empty_with_fallback(
     collection: Array,
     fallback := null,
     context: String = "Collection",
 ) -> Dictionary:
-    """
-    Handle empty collections by optionally falling back to ``fallback``.
-
-    The return value communicates whether the fallback was used so callers can
-    avoid ambiguous ``null`` checks.
-
-    Returns a dictionary with two keys:
-    - ``was_empty``: ``true`` if ``collection`` was empty.
-    - ``value``: The fallback value (when provided) or ``null``.
-
-    The helper must remain free of global randomness.  Only the caller decides
-    how to generate fallback content, ensuring deterministic behaviour in tests
-    and save/load scenarios.
-    """
     var state := {
         "was_empty": false,
         "value": null,
@@ -65,70 +76,7 @@ static func handle_empty_with_fallback(
 
     return state
 
-
-static func pick_random_deterministic(items: Array, rng: RandomNumberGenerator) -> Variant:
-    """
-    Pick a random element from ``items`` using the provided ``rng`` only.
-
-    The helper never touches ``RandomNumberGenerator``'s global state so the
-    caller retains deterministic control.
-    """
-    assert_not_empty(items, "Items")
-
-    if items.size() == 1:
-        return items[0]
-
-    # Use the caller-supplied RNG exclusively to stay deterministic.
-    var index := rng.randi_range(0, items.size() - 1)
-    return items[index]
-
-
-static func pick_weighted_random_deterministic(entries: Array, rng: RandomNumberGenerator) -> Variant:
-    """
-    Pick a weighted entry from ``entries`` using the supplied ``rng`` only.
-
-    Each entry can be either a dictionary or a two-element array:
-    - ``{"value": value, "weight": number}``
-    - ``{"item": value, "weight": number}``
-    - ``[value, weight]``
-
-    The function intentionally avoids any reliance on global randomness to keep
-    simulations deterministic when the caller provides a seeded RNG.
-    """
-    assert_not_empty(entries, "Weighted entries")
-
-    var normalized_entries: Array = []
-    var total_weight := 0.0
-
-    for entry in entries:
-        var parsed := _parse_weighted_entry(entry)
-        total_weight += parsed["weight"]
-        normalized_entries.append(parsed)
-
-    if total_weight <= 0.0:
-        var message := "Weighted entries must have a combined positive weight."
-        push_error(message)
-        assert(false, message)
-
-    # Roll against the total weight using only the provided RNG.
-    var roll := rng.randf() * total_weight
-    var cumulative := 0.0
-
-    for entry in normalized_entries:
-        cumulative += entry["weight"]
-        if roll <= cumulative:
-            return entry["value"]
-
-    return normalized_entries.back()["value"]
-
-
 static func _parse_weighted_entry(entry: Variant) -> Dictionary:
-    """
-    Convert ``entry`` into a dictionary with ``value`` and ``weight`` keys.
-
-    The helper only performs deterministic validation and does not use any
-    randomness.
-    """
     var value := null
     var weight := null
 

--- a/tests/test_assets/README.md
+++ b/tests/test_assets/README.md
@@ -1,3 +1,12 @@
 # Test Assets
 
-This folder hosts data fixtures consumed by automated test suites. The current generator strategy tests operate entirely in code, so no external fixtures are required yet. Add new resources here when future suites need sample syllable sets, word lists, or serialized strategy configs.
+This folder hosts data fixtures consumed by automated test suites.
+
+- `wordlist_basic.tres` – Minimal `WordListResource` used by the hybrid strategy
+  tests.
+- `syllable_basic.tres` – Basic `SyllableSetResource` providing a short prefix /
+  suffix catalogue.
+- `markov_basic.tres` – Tiny `MarkovModelResource` that emits deterministic
+  syllable pairs for integration scenarios.
+
+Add additional resources here when future suites need richer datasets.

--- a/tests/test_assets/markov_basic.tres
+++ b/tests/test_assets/markov_basic.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("ka", "la", "mo", "ri")
+start_tokens = [{"token": "ka", "weight": 1.0}, {"token": "mo", "weight": 1.0}]
+transitions = {
+"ka": [{"token": "la", "weight": 1.0}],
+"la": [{"token": "<END>", "weight": 1.0}],
+"mo": [{"token": "ri", "weight": 1.0}],
+"ri": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0

--- a/tests/test_assets/syllable_basic.tres
+++ b/tests/test_assets/syllable_basic.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Ka", "Mo")
+middles = PackedStringArray("la", "ri")
+suffixes = PackedStringArray("th", "dor")
+allow_empty_middle = true

--- a/tests/test_assets/wordlist_basic.tres
+++ b/tests/test_assets/wordlist_basic.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Brave", "Mighty", "Shadow")
+weighted_entries = [{"value": "Brave", "weight": 2.0}, {"value": "Mighty", "weight": 1.0}, {"value": "Shadow", "weight": 0.5}]

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -3,6 +3,10 @@
     {
       "name": "Generator Strategy Suite",
       "path": "res://name_generator/tests/test_generator_strategy.gd"
+    },
+    {
+      "name": "Hybrid Strategy Suite",
+      "path": "res://name_generator/tests/test_hybrid_strategy.gd"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- align RNGManager and NameGenerator singletons with the deterministic architecture from DevDoc
- consolidate strategy base classes and update wordlist, syllable, template, and Markov strategies to the documented interfaces
- introduce a hybrid strategy that composes other generators, add sample resources, documentation, and automated tests

## Testing
- godot --headless --script res://tests/run_all_tests.gd *(fails: Godot CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab5c064d883208e6a945583f4c37a