### PR TITLE
Add DebugRNG instrumentation and tests

### DIFF
--- a/name_generator/tests/test_debug_rng.gd
+++ b/name_generator/tests/test_debug_rng.gd
@@ -1,0 +1,145 @@
+extends RefCounted
+
+const DebugRNG := preload("res://name_generator/tools/DebugRNG.gd")
+const RNGProcessor := preload("res://name_generator/RNGProcessor.gd")
+
+const WORDLIST_PATH := "res://tests/test_assets/wordlist_basic.tres"
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _reset()
+
+    _run_test("report_includes_generation_events", func(): _test_report_includes_generation_events())
+
+    return {
+        "suite": "Debug RNG",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+        return
+
+    _failed += 1
+    _failures.append({
+        "name": name,
+        "message": String(message),
+    })
+
+func _test_report_includes_generation_events() -> Variant:
+    var processor := _make_processor()
+    var debug_rng := DebugRNG.new()
+    var log_path := "user://debug_rng_report_test.txt"
+    _remove_file(log_path)
+
+    debug_rng.begin_session({
+        "test": "report_includes_generation_events",
+    })
+    debug_rng.attach_to_processor(processor, log_path)
+
+    processor.initialize_master_seed(10101)
+
+    debug_rng.record_warning("pre-flight warning", {"stage": "setup"})
+
+    var success_config := {
+        "strategy": "wordlist",
+        "wordlist_paths": [WORDLIST_PATH],
+        "seed": "debug_rng_success",
+    }
+
+    var success := processor.generate(success_config)
+    if success is Dictionary and success.get("code", "") != "":
+        return "Expected successful configuration to produce a generated value."
+
+    var failure_config := {
+        "strategy": "wordlist",
+        "wordlist_paths": [],
+        "seed": "debug_rng_failure",
+    }
+
+    var failure := processor.generate(failure_config)
+    if not (failure is Dictionary) or failure.get("code", "") == "":
+        return "Expected failure configuration to surface an error dictionary."
+
+    debug_rng.record_warning("post-failure note", {"stage": "teardown"})
+
+    debug_rng.close()
+
+    var file := FileAccess.open(log_path, FileAccess.READ)
+    if file == null:
+        return "DebugRNG must write the report to disk on close."
+
+    var report := file.get_as_text()
+    if report.find("Session Metadata") == -1:
+        return "Report should include a Session Metadata section."
+
+    if report.find("Generation Timeline") == -1:
+        return "Report should include a Generation Timeline section."
+
+    var start_index := report.find("START")
+    var complete_index := report.find("COMPLETE")
+    var fail_index := report.find("FAIL")
+    if start_index == -1 or complete_index == -1 or fail_index == -1:
+        return "Timeline must document start, completion, and failure events."
+
+    if not (start_index < complete_index and complete_index < fail_index):
+        return "Timeline entries should appear in chronological order."
+
+    if report.find("STRATEGY_ERROR") == -1:
+        return "Strategy errors should be captured in the timeline."
+
+    if report.find("pre-flight warning") == -1 or report.find("post-failure note") == -1:
+        return "Warnings section must include recorded diagnostics."
+
+    if report.find("Stream Usage") == -1:
+        return "Report should contain a Stream Usage section."
+
+    if report.find("wordlist::debug_rng_success") == -1:
+        return "Stream usage must document derived RNG streams."
+
+    if report.find("Total Calls: 2") == -1:
+        return "Aggregate stats should report the total number of invocations."
+
+    if report.find("Successful Calls: 1") == -1:
+        return "Aggregate stats should track successful requests."
+
+    if report.find("Failed Calls: 1") == -1:
+        return "Aggregate stats should track failed requests."
+
+    if report.find("Strategy Errors: 1") == -1:
+        return "Aggregate stats should include strategy error counts."
+
+    if report.find("Warnings: 2") == -1:
+        return "Aggregate stats should include warning counts."
+
+    if report.find("Stream Records: 0") != -1:
+        return "Stream usage count should be greater than zero."
+
+    return null
+
+func _make_processor() -> RNGProcessor:
+    var processor := RNGProcessor.new()
+    processor._ready()
+    return processor
+
+func _reset() -> void:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+func _remove_file(path: String) -> void:
+    if not FileAccess.file_exists(path):
+        return
+    DirAccess.remove_absolute(path)
+*** End Patch

--- a/name_generator/tools/DebugRNG.gd
+++ b/name_generator/tools/DebugRNG.gd
@@ -1,0 +1,336 @@
+extends RefCounted
+class_name DebugRNG
+
+## DebugRNG collects detailed telemetry about name generation runs.
+##
+## The helper can attach to an RNGProcessor instance to record the middleware
+## lifecycle and hook into GeneratorStrategy failures. Consumers may also push
+## ad-hoc diagnostics (warnings, stream usages, notes) into the log via the
+## exposed helper APIs. When the session ends, DebugRNG serializes a structured
+## plain-text report so teams can share reproducible investigations.
+
+const DEFAULT_LOG_PATH := "user://debug_rng_report.txt"
+
+var _log_path := DEFAULT_LOG_PATH
+var _session_open := false
+var _session_metadata: Dictionary = {}
+var _log_entries: Array[Dictionary] = []
+var _stats := {
+    "calls_started": 0,
+    "calls_completed": 0,
+    "calls_failed": 0,
+    "strategy_errors": 0,
+    "warnings": 0,
+    "stream_records": 0,
+}
+var _attached_processor: Object = null
+var _tracked_strategies: Dictionary = {}
+var _session_started_at := ""
+var _session_ended_at := ""
+
+func begin_session(metadata: Dictionary = {}) -> void:
+    ## Start a new logging session and capture optional metadata to include in
+    ## the serialized report.
+    _session_open = true
+    _session_metadata = metadata.duplicate(true)
+    _session_started_at = _current_timestamp()
+    _session_ended_at = ""
+    _log_entries.clear()
+    _stats = {
+        "calls_started": 0,
+        "calls_completed": 0,
+        "calls_failed": 0,
+        "strategy_errors": 0,
+        "warnings": 0,
+        "stream_records": 0,
+    }
+
+func attach_to_processor(processor: Object, log_path: String = DEFAULT_LOG_PATH, propagate_to_processor: bool = true) -> void:
+    ## Attach DebugRNG to an RNGProcessor so it can observe middleware events.
+    if processor == null:
+        return
+
+    if log_path.strip_edges() != "":
+        _log_path = log_path.strip_edges()
+
+    if _attached_processor != null and is_instance_valid(_attached_processor) and _attached_processor != processor:
+        detach_from_processor(_attached_processor)
+
+    _attached_processor = processor
+
+    if processor.has_signal("generation_started"):
+        var started_callable := Callable(self, "_on_generation_started")
+        if not processor.is_connected("generation_started", started_callable):
+            processor.connect("generation_started", started_callable, CONNECT_REFERENCE_COUNTED)
+    if processor.has_signal("generation_completed"):
+        var completed_callable := Callable(self, "_on_generation_completed")
+        if not processor.is_connected("generation_completed", completed_callable):
+            processor.connect("generation_completed", completed_callable, CONNECT_REFERENCE_COUNTED)
+    if processor.has_signal("generation_failed"):
+        var failed_callable := Callable(self, "_on_generation_failed")
+        if not processor.is_connected("generation_failed", failed_callable):
+            processor.connect("generation_failed", failed_callable, CONNECT_REFERENCE_COUNTED)
+
+    if propagate_to_processor and processor.has_method("set_debug_rng"):
+        processor.call("set_debug_rng", self, false)
+
+func detach_from_processor(processor: Object = null) -> void:
+    ## Disconnect from the bound RNGProcessor.
+    var target := processor if processor != null else _attached_processor
+    if target == null or not is_instance_valid(target):
+        _attached_processor = null
+        return
+
+    if target.has_signal("generation_started"):
+        if target.is_connected("generation_started", Callable(self, "_on_generation_started")):
+            target.disconnect("generation_started", Callable(self, "_on_generation_started"))
+    if target.has_signal("generation_completed"):
+        if target.is_connected("generation_completed", Callable(self, "_on_generation_completed")):
+            target.disconnect("generation_completed", Callable(self, "_on_generation_completed"))
+    if target.has_signal("generation_failed"):
+        if target.is_connected("generation_failed", Callable(self, "_on_generation_failed")):
+            target.disconnect("generation_failed", Callable(self, "_on_generation_failed"))
+
+    if _attached_processor == target:
+        _attached_processor = null
+
+func track_strategy(strategy_id: String, strategy: Object) -> void:
+    ## Observe generation_error emissions from a GeneratorStrategy instance.
+    if strategy == null:
+        return
+    var key := strategy.get_instance_id()
+    if _tracked_strategies.has(key):
+        _tracked_strategies[key]["id"] = strategy_id
+        return
+
+    var callable := Callable(self, "_on_strategy_error").bind(strategy_id)
+    if strategy.has_signal("generation_error"):
+        var error := strategy.connect("generation_error", callable, CONNECT_REFERENCE_COUNTED)
+        if error == OK:
+            _tracked_strategies[key] = {
+                "strategy": strategy,
+                "id": strategy_id,
+            }
+
+func untrack_strategy(strategy: Object) -> void:
+    ## Stop observing a previously tracked strategy.
+    if strategy == null:
+        return
+    var key := strategy.get_instance_id()
+    if not _tracked_strategies.has(key):
+        return
+
+    var metadata := _tracked_strategies[key]
+    _tracked_strategies.erase(key)
+
+    if strategy.has_signal("generation_error"):
+        var callable := Callable(self, "_on_strategy_error").bind(metadata.get("id", ""))
+        if strategy.is_connected("generation_error", callable):
+            strategy.disconnect("generation_error", callable)
+
+func clear_tracked_strategies() -> void:
+    ## Disconnect from every tracked strategy.
+    for entry in _tracked_strategies.values():
+        var strategy := entry.get("strategy", null)
+        if strategy != null and is_instance_valid(strategy):
+            var callable := Callable(self, "_on_strategy_error").bind(entry.get("id", ""))
+            if strategy.has_signal("generation_error") and strategy.is_connected("generation_error", callable):
+                strategy.disconnect("generation_error", callable)
+    _tracked_strategies.clear()
+
+func record_warning(message: String, context: Dictionary = {}) -> void:
+    ## Append a warning record to the log so tooling can surface diagnostics
+    ## unrelated to explicit failures.
+    _stats["warnings"] += 1
+    _log_entries.append({
+        "type": "warning",
+        "timestamp": _current_timestamp(),
+        "message": message,
+        "context": context.duplicate(true),
+    })
+
+func record_stream_usage(stream_name: String, context: Dictionary = {}) -> void:
+    ## Track when a deterministic RNG stream is resolved or consumed. This helps
+    ## correlate derived RNG state with downstream generation steps.
+    _stats["stream_records"] += 1
+    _log_entries.append({
+        "type": "stream_usage",
+        "timestamp": _current_timestamp(),
+        "stream": stream_name,
+        "context": context.duplicate(true),
+    })
+
+func close() -> void:
+    ## Finalize the session and write the accumulated report to disk.
+    if not _session_open and _log_entries.is_empty():
+        return
+
+    _session_open = false
+    _session_ended_at = _current_timestamp()
+
+    var lines := _serialize_report()
+    var file := FileAccess.open(_log_path, FileAccess.WRITE)
+    if file == null:
+        push_error("DebugRNG could not open log file at %s" % _log_path)
+        return
+
+    for line in lines:
+        file.store_line(line)
+
+func dispose() -> void:
+    ## Alias for close() to match familiar resource lifecycles.
+    close()
+
+func _on_generation_started(config: Dictionary, metadata: Dictionary) -> void:
+    _stats["calls_started"] += 1
+    _log_entries.append({
+        "type": "generation_started",
+        "timestamp": _current_timestamp(),
+        "config": _duplicate_variant(config),
+        "metadata": _duplicate_variant(metadata),
+    })
+
+func _on_generation_completed(config: Dictionary, result: Variant, metadata: Dictionary) -> void:
+    _stats["calls_completed"] += 1
+    _log_entries.append({
+        "type": "generation_completed",
+        "timestamp": _current_timestamp(),
+        "config": _duplicate_variant(config),
+        "metadata": _duplicate_variant(metadata),
+        "result": _duplicate_variant(result),
+    })
+
+func _on_generation_failed(config: Dictionary, error: Dictionary, metadata: Dictionary) -> void:
+    _stats["calls_failed"] += 1
+    _log_entries.append({
+        "type": "generation_failed",
+        "timestamp": _current_timestamp(),
+        "config": _duplicate_variant(config),
+        "metadata": _duplicate_variant(metadata),
+        "error": _duplicate_variant(error),
+    })
+
+func _on_strategy_error(strategy_id: String, code: String, message: String, details: Dictionary) -> void:
+    _stats["strategy_errors"] += 1
+    _log_entries.append({
+        "type": "strategy_error",
+        "timestamp": _current_timestamp(),
+        "strategy_id": strategy_id,
+        "code": code,
+        "message": message,
+        "details": _duplicate_variant(details),
+    })
+
+func _serialize_report() -> PackedStringArray:
+    var lines := PackedStringArray()
+    lines.append("Debug RNG Report")
+    lines.append("================")
+    lines.append("")
+
+    lines.append("Session Metadata")
+    lines.append("----------------")
+    lines.append("Started At: %s" % _session_started_at)
+    lines.append("Ended At: %s" % _session_ended_at)
+    for key in _session_metadata.keys():
+        lines.append("%s: %s" % [String(key), _stringify_value(_session_metadata[key])])
+    lines.append("")
+
+    lines.append("Generation Timeline")
+    lines.append("-------------------")
+    var index := 1
+    for entry in _log_entries:
+        match entry.get("type", ""):
+            "generation_started":
+                lines.append("[%d] START %s strategy=%s seed=%s stream=%s" % [
+                    index,
+                    entry["timestamp"],
+                    entry.get("metadata", {}).get("strategy_id", ""),
+                    entry.get("metadata", {}).get("seed", ""),
+                    entry.get("metadata", {}).get("rng_stream", ""),
+                ])
+                index += 1
+            "generation_completed":
+                lines.append("[%d] COMPLETE %s strategy=%s result=%s" % [
+                    index,
+                    entry["timestamp"],
+                    entry.get("metadata", {}).get("strategy_id", ""),
+                    _stringify_value(entry.get("result", "")),
+                ])
+                index += 1
+            "generation_failed":
+                lines.append("[%d] FAIL %s strategy=%s code=%s" % [
+                    index,
+                    entry["timestamp"],
+                    entry.get("metadata", {}).get("strategy_id", ""),
+                    entry.get("error", {}).get("code", ""),
+                ])
+                index += 1
+            "strategy_error":
+                lines.append("[%d] STRATEGY_ERROR %s strategy=%s code=%s message=%s" % [
+                    index,
+                    entry["timestamp"],
+                    entry.get("strategy_id", ""),
+                    entry.get("code", ""),
+                    entry.get("message", ""),
+                ])
+                index += 1
+            _:
+                continue
+    if index == 1:
+        lines.append("No generation activity recorded.")
+    lines.append("")
+
+    lines.append("Warnings")
+    lines.append("--------")
+    var warnings := _log_entries.filter(func(e): return e.get("type", "") == "warning")
+    if warnings.is_empty():
+        lines.append("None recorded.")
+    else:
+        for warning in warnings:
+            lines.append("- %s -- %s %s" % [
+                warning.get("timestamp", ""),
+                warning.get("message", ""),
+                _stringify_value(warning.get("context", {})),
+            ])
+    lines.append("")
+
+    lines.append("Stream Usage")
+    lines.append("------------")
+    var streams := _log_entries.filter(func(e): return e.get("type", "") == "stream_usage")
+    if streams.is_empty():
+        lines.append("No stream usage recorded.")
+    else:
+        for stream in streams:
+            lines.append("- %s -- %s %s" % [
+                stream.get("timestamp", ""),
+                stream.get("stream", ""),
+                _stringify_value(stream.get("context", {})),
+            ])
+    lines.append("")
+
+    lines.append("Aggregate Statistics")
+    lines.append("---------------------")
+    lines.append("Total Calls: %d" % _stats.get("calls_started", 0))
+    lines.append("Successful Calls: %d" % _stats.get("calls_completed", 0))
+    lines.append("Failed Calls: %d" % _stats.get("calls_failed", 0))
+    lines.append("Strategy Errors: %d" % _stats.get("strategy_errors", 0))
+    lines.append("Warnings: %d" % _stats.get("warnings", 0))
+    lines.append("Stream Records: %d" % _stats.get("stream_records", 0))
+
+    return lines
+
+func _current_timestamp() -> String:
+    return Time.get_datetime_string_from_system(false, true)
+
+func _stringify_value(value: Variant) -> String:
+    if value is String:
+        return value
+    var json := JSON.new()
+    return json.stringify(value)
+
+func _duplicate_variant(value: Variant) -> Variant:
+    if value is Dictionary:
+        return (value as Dictionary).duplicate(true)
+    if value is Array:
+        return (value as Array).duplicate(true)
+    return value

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -9,6 +9,10 @@
       "path": "res://name_generator/tests/test_hybrid_strategy.gd"
     },
     {
+      "name": "Debug RNG Suite",
+      "path": "res://name_generator/tests/test_debug_rng.gd"
+    },
+    {
       "name": "RNG Processor Suite",
       "path": "res://name_generator/tests/test_rng_processor.gd"
     }


### PR DESCRIPTION
## Summary
- add a DebugRNG helper that records RNGProcessor sessions and serializes structured reports
- hook NameGenerator and RNGProcessor into the debug helper so stream derivations and strategy failures are captured
- cover the new functionality with a focused Debug RNG test suite and update the manifest

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae165cab08320a82c6ac59ee6e424