### PR TITLE
Document RNGProcessor middleware and DebugRNG logging

### DIFF
--- a/DevDoc.txt
+++ b/DevDoc.txt
@@ -308,6 +308,8 @@ The correct save/load procedure is therefore:
 	* Call a function on the RNGManager (like set_all_states() above) to iterate through the loaded states and restore the state property of each corresponding RNG instance.
 This two-step process ensures that upon loading, every random stream in the game is in the exact same condition it was in when the game was saved, guaranteeing perfect deterministic continuity.
 
+For day-to-day integration guidance on the middleware that wraps these systems, consult the new `docs/rng_processor_manual.md` (responsibilities, API, DebugRNG logging) and `devdocs/rng_processor.md` (task-oriented field guide). Both references explain how the autoloaded `RNGProcessor` coordinates with `RNGManager` and the `NameGenerator` façade while supporting the upcoming Platform GUI.
+
 Part II: Implementing the Generation Strategies
 
 With the foundational architecture for the NameGenerator, data management, and deterministic randomness established, this section focuses on the practical implementation of the individual generation algorithms. Each of the following chapters will detail a specific GeneratorStrategy, covering its underlying concept, use cases, data requirements, and a complete implementation in GDScript. These strategies are the modular, interchangeable components that give the Universal Name Generator its power and flexibility.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# RNGEN Documentation Hub
+
+This repository hosts the Godot 4.4 project that powers the deterministic name generation stack. The runtime is organised around three autoloaded singletons:
+
+- `RNGManager` – Governs the master seed and hands out isolated `RandomNumberGenerator` streams.
+- `NameGenerator` – Provides the extensible strategy façade for gameplay and tools.
+- `RNGProcessor` – Middleware that coordinates requests, surfaces telemetry, and underpins forthcoming platform UI features.
+
+## Documentation map
+
+| Audience | Start here | Highlights |
+| --- | --- | --- |
+| System designers | `DevDoc.txt` | Architectural rationale, deterministic design patterns, strategy deep dives. |
+| Integrators & tool engineers | `docs/rng_processor_manual.md` | Middleware responsibilities, API/signal reference, DebugRNG log format, Platform GUI context. |
+| Gameplay programmers | `devdocs/rng_processor.md` | Task-focused guide (initialising the processor, registering custom strategies, running tests, capturing logs). |
+| Content authors | `devdocs/strategies.md`, `name_generator/resources/README.md` | Resource authoring workflows and data expectations. |
+
+Additional sub-system references:
+
+- `name_generator/README.md` – Module layout plus RNGProcessor integration notes.
+- `name_generator/tools/README.md` – CLI/editor tooling, including links back to the middleware manual.
+
+## Running the tests
+
+Execute the automated suite from the repository root to validate gameplay strategies, middleware, and tooling scripts:
+
+```bash
+godot --headless --script res://tests/run_all_tests.gd
+```
+
+Refer to `devdocs/tooling.md` for complementary QA workflows.

--- a/devdocs/rng_processor.md
+++ b/devdocs/rng_processor.md
@@ -1,0 +1,56 @@
+# RNGProcessor Field Guide
+
+This guide is aimed at engineers who are integrating the name generation stack into gameplay or external tooling. It assumes you are familiar with Godot’s autoload system and the deterministic architecture described in `DevDoc.txt`.
+
+## 1. Initialising the processor in-game
+
+1. Confirm that `project.godot` lists `RNGManager`, `NameGenerator`, and `RNGProcessor` in the `[autoload]` section. The repository ships with this configuration, so most teams only need to ensure they do not remove it from custom builds.
+2. During your game’s bootstrap sequence, seed the middleware once:
+   ```gdscript
+   var master_seed := RNGProcessor.randomize_master_seed()
+   DebugPrint.info("Master seed", master_seed)
+   ```
+   Alternatively, set a reproducible seed retrieved from a save file with `RNGProcessor.set_master_seed(saved_seed)`.
+3. When you need a name, call `RNGProcessor.generate(config_dictionary)`. The middleware handles RNG stream derivation and signal emission automatically.
+
+If you instantiate `RNGProcessor` manually (e.g., inside an isolated test scene), call `add_child(RNGProcessor.new())` early in your scene tree and invoke `_ready()` or `initialize_master_seed(...)` before dispatching requests. The autoload setup already covers this for the main project.
+
+## 2. Registering custom strategies
+
+1. Create a script that extends `GeneratorStrategy` (see `devdocs/strategies.md` for scaffolding tips).
+2. Register the strategy during startup by calling `NameGenerator.register_strategy("your_id", YourStrategy.new())`. `RNGProcessor.list_strategies()` immediately reflects the new entry; the middleware simply proxies the generator’s registry.
+3. If you attach `DebugRNG`, the processor automatically instructs the generator to track your strategy, so `generation_error` signals will appear in the TXT logs when your code returns failures.
+4. Update your client code or data definitions to supply the new `strategy` identifier inside the configuration dictionaries passed to `RNGProcessor.generate`.
+
+## 3. Running the headless test suite
+
+The repository bundles regression coverage for the middleware and related components. Run the suite from the project root:
+
+```bash
+godot --headless --script res://tests/run_all_tests.gd
+```
+
+This exercises both the in-engine tests (`name_generator/tests/*.gd`) and any headless scenarios (`tests/test_rng_processor_headless.gd`) that rely on the middleware. Attach the `DebugRNG` helper during new tests if you need additional telemetry—the suite already records warnings so logs stay informative.
+
+## 4. Collecting DebugRNG logs
+
+1. Instantiate and attach the helper:
+   ```gdscript
+   var debug_rng := DebugRNG.new()
+   debug_rng.begin_session({
+       "build": ProjectSettings.get_setting("application/config/version"),
+       "scenario": "qa_smoke"
+   })
+   debug_rng.attach_to_processor(RNGProcessor)
+   ```
+2. Execute the scenarios you need to trace. Every `generation_started`, `generation_completed`, and `generation_failed` signal will appear in the timeline section.
+3. When finished, call `debug_rng.close()` (or `debug_rng.dispose()`). The report is written to `user://debug_rng_report.txt` unless you passed a custom path to `attach_to_processor`.
+4. Zip and share the TXT file with support or attach it to bug reports. The layout is documented in `docs/rng_processor_manual.md`.
+
+## 5. Troubleshooting checklist
+
+- **Missing names** – Confirm `NameGenerator` is present by checking the error dictionaries emitted via `generation_failed`. A `missing_name_generator` code indicates the autoload was removed.
+- **Unexpected randomness** – Inspect the “Stream Usage” section in the DebugRNG log. It shows whether custom `rng_stream` overrides or auto-derived streams drove a request.
+- **Custom strategy silent failures** – Ensure your strategy emits `generation_error` signals via `GeneratorStrategy._report_error`. DebugRNG listens for them and exposes counts in the “Aggregate Statistics” section.
+
+For a comprehensive API reference, jump to `docs/rng_processor_manual.md`.

--- a/docs/rng_processor_manual.md
+++ b/docs/rng_processor_manual.md
@@ -1,0 +1,84 @@
+# RNGProcessor Middleware Manual
+
+## Overview
+
+`RNGProcessor` is the deterministic middleware that bridges gameplay systems and the `NameGenerator` / `RNGManager` singletons. It ships as a Godot autoload (see `project.godot`) so editor tools, tests, and runtime code can rely on a stable API surface without managing node lifecycles. The processor
+
+- normalises seed handling across every request,
+- shields callers from direct dependencies on `NameGenerator` internals,
+- emits structured signals that analytics dashboards and the forthcoming Platform GUI can observe, and
+- exposes hooks for attaching the `DebugRNG` telemetry helper.
+
+The class lives at `res://name_generator/RNGProcessor.gd` and can be retrieved anywhere in project code through `Engine.get_singleton("RNGProcessor")` or the global shorthand `RNGProcessor`.
+
+## Core responsibilities
+
+1. **Seed governance** – `RNGProcessor` forwards seed mutations to `RNGManager` when available and maintains lightweight fallbacks for isolated tests. This ensures a single source of truth for the master seed regardless of the execution environment.
+2. **Request brokering** – All `NameGenerator.generate(...)` calls can be routed through the processor. It performs defensive checks, forwards successful invocations, and surfaces structured errors when the generator singleton is unavailable.
+3. **Observability & telemetry** – The middleware emits start/finish/failure signals and, when paired with `DebugRNG`, records RNG stream derivations. These guarantees are what the Platform GUI will rely on to render live job timelines and replay previous sessions deterministically.
+
+## Public API quick reference
+
+### Seed control
+
+- `initialize_master_seed(seed_value: int)` / `set_master_seed(seed_value: int)` – Apply an explicit session seed and flush any cached fallback streams.
+- `randomize_master_seed() -> int` – Generate a fresh seed via `RandomNumberGenerator`, broadcast it to `RNGManager`, and return the value so callers can persist it.
+- `reset_master_seed() -> int` – Alias that randomises and returns the new seed; helpful for UI buttons that need to display the updated value immediately.
+- `get_master_seed() -> int` – Query the currently active master seed (falls back to the processor’s cached copy when `RNGManager` is not registered, e.g. during headless unit tests).
+- `get_rng(stream_name: String) -> RandomNumberGenerator` – Request a deterministic stream. When `RNGManager` is present the call is proxied; otherwise a hashed fallback stream derived from the current master seed is served.
+
+### Request execution & strategy metadata
+
+- `list_strategies() -> PackedStringArray` – Enumerate the registered generator strategies without touching the `NameGenerator` internals. The Platform GUI uses this call to populate dropdowns dynamically.
+- `describe_strategy(id: String) -> Dictionary` and `describe_strategies() -> Dictionary` – Fetch per-strategy metadata, including expected configuration schemas, for tooling validation layers.
+- `generate(config: Variant, override_rng: RandomNumberGenerator = null) -> Variant` – Execute a generation request through `NameGenerator`. The processor emits lifecycle signals (described below) and mirrors any error payloads from the generator, making it safe for UI code to inspect failure codes without digging into strategy implementations.
+
+### Signals & observability hooks
+
+- `generation_started(request_config, metadata)` – Fired before delegating to `NameGenerator`. `metadata` includes the resolved strategy identifier, seed (when provided), and RNG stream name.
+- `generation_completed(request_config, result, metadata)` – Fired after a successful run. `result` is the raw payload returned by the active strategy.
+- `generation_failed(request_config, error, metadata)` – Fired when the generator is missing or a strategy reports a structured error. The signal payload mirrors the dictionary returned by `NameGenerator.generate`.
+- `set_debug_rng(debug_rng: DebugRNG, attach_to_debug := true)` / `get_debug_rng()` – Attach or inspect a `DebugRNG` observer. When `attach_to_debug` is `true`, the helper automatically begins monitoring lifecycle signals and propagates itself to `NameGenerator` so strategy-level events are also captured.
+
+These surface areas are what the Platform GUI will observe. By listening to the signals, the UI can show per-request timelines, associate results with RNG stream derivations, and offer “re-run with same seed” affordances without needing private knowledge of the name generator.
+
+## DebugRNG integration and log reference
+
+`DebugRNG` (located at `res://name_generator/tools/DebugRNG.gd`) serialises a human-readable TXT report after each session. Attach it to the processor with:
+
+```gdscript
+var debug_rng := DebugRNG.new()
+debug_rng.begin_session({"suite": "platform_smoke"})
+debug_rng.attach_to_processor(RNGProcessor, "user://debug_rng_report.txt")
+```
+
+### Default location and configuration knobs
+
+- **Default path** – `DebugRNG.DEFAULT_LOG_PATH` resolves to `user://debug_rng_report.txt`. Pass a custom path to `attach_to_processor(processor, log_path)` to redirect the output. The helper remembers the last non-empty path you supplied.
+- **Session metadata** – Call `begin_session(metadata := {})` before triggering jobs to record build identifiers, platform details, or scenario names in the report’s header.
+- **Lifecycle management** – Invoke `close()` (or the alias `dispose()`) when you are done to flush the accumulated log to disk. When attached through `RNGProcessor.set_debug_rng(...)`, closing is handled automatically once the helper is disposed by tooling code.
+- **Stream tracking** – The processor forwards stream derivations through `record_stream_usage(stream_name, context)` so you can map every derived RNG stream back to the original request.
+
+### TXT report layout
+
+When `close()` executes, DebugRNG writes a structured plaintext document with the following sections:
+
+1. **Header** – Title plus blank separator line.
+2. **Session Metadata** – Start/end timestamps followed by any key/value pairs passed into `begin_session`.
+3. **Generation Timeline** – Ordered entries (`START`, `COMPLETE`, `FAIL`, `STRATEGY_ERROR`) that chronicle each middleware signal, including timestamps, strategy identifiers, seeds, stream names, and either results or error codes.
+4. **Warnings** – Optional bullet list populated through `record_warning(message, context)`.
+5. **Stream Usage** – Bullet list enumerating each RNG stream recorded along with contextual metadata (strategy, seed, and whether the stream came from a config override or derived fallback).
+6. **Aggregate Statistics** – Totals for started/completed/failed calls, strategy errors, warnings, and stream records.
+
+Support engineers investigating issues should grab the latest `user://debug_rng_report.txt` (or whatever path their tooling configured) from the affected machine and attach it to bug reports. The Platform GUI will offer a “Download DebugRNG log” button that simply copies this file.
+
+## Relationship to the Platform GUI
+
+The planned Platform GUI is effectively a front-end that consumes the middleware API documented above. It will:
+
+- use `list_strategies()` / `describe_strategies()` to populate configuration forms,
+- call `generate(...)` with the requested seed and stream overrides,
+- subscribe to the lifecycle signals to animate status indicators, and
+- display DebugRNG session metadata and stream usage summaries inside its troubleshooting panel.
+
+Because the middleware already decouples callers from `NameGenerator` internals, the GUI (and any other client) can evolve independently while keeping compatibility guarantees: as long as the documented API surface remains stable, existing automation and tooling will continue to function without modification.

--- a/name_generator/README.md
+++ b/name_generator/README.md
@@ -30,6 +30,30 @@ colliding.
   `generate(config)` calls to the correct strategy while sourcing RNG streams
   from `RNGManager`.
 
+## RNGProcessor middleware
+
+`RNGProcessor.gd` is autoloaded alongside the generator and RNG manager. The
+middleware is the recommended entry point for clients that want deterministic
+results plus observability without touching the underlying singletons directly.
+
+- **Obtaining results** – Call `RNGProcessor.generate(config)` instead of
+  invoking `NameGenerator` yourself. The processor resolves the RNG stream,
+  forwards the request, and emits `generation_started`, `generation_completed`,
+  or `generation_failed` signals that UI layers and automation harnesses can
+  observe.
+- **Discovering strategies** – Ask the middleware for
+  `RNGProcessor.list_strategies()` or `RNGProcessor.describe_strategies()` to
+  populate dropdowns or drive config validation. The methods mirror the
+  generator’s metadata but avoid coupling tool code to its internal registry.
+- **DebugRNG integration** – Attach `DebugRNG` via
+  `RNGProcessor.set_debug_rng(...)` to collect TXT logs that detail every
+  generation call, stream derivation, and warning. The helper defaults to
+  `user://debug_rng_report.txt` but accepts a custom path when you call
+  `attach_to_processor` on the helper.
+
+See `docs/rng_processor_manual.md` for a complete API walkthrough and logging
+reference.
+
 ## Strategy overview
 
 All strategies extend `GeneratorStrategy`, which standardises configuration

--- a/name_generator/tools/README.md
+++ b/name_generator/tools/README.md
@@ -15,6 +15,8 @@ Add new scripts alongside `dataset_inspector.gd` and update the developer docs (
 
 This directory hosts editor tooling that supports designers while curating data for the procedural name generator.
 
+For middleware-specific automation guidance (attaching `DebugRNG`, enumerating strategies, or sourcing deterministic streams), see `docs/rng_processor_manual.md` and the workflow examples in `devdocs/rng_processor.md`.
+
 ## Syllable Set Builder
 
 The `SyllableSetBuilder` editor plugin adds a dock that converts curated word lists into [`SyllableSetResource`](../resources/SyllableSetResource.gd) files. Enable the plugin from **Project → Project Settings → Plugins** and look for *Syllable Set Builder*.


### PR DESCRIPTION
## Summary
- add a dedicated RNGProcessor middleware manual covering responsibilities, API hooks, and DebugRNG logging details
- introduce a field guide for engineers that explains initialization, strategy registration, headless tests, and log collection workflows
- update existing READMEs and DevDoc cross-links so teams can find the new documentation easily

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caea7c53e88320ba9806d980954f4f