### PR TITLE
Document diagnostic runner usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,10 @@ Execute the automated suite from the repository root to validate gameplay strate
 godot --headless --script res://tests/run_all_tests.gd
 ```
 
-Refer to `devdocs/tooling.md` for complementary QA workflows.
+For targeted debugging, the diagnostics runner executes an individual scenario declared in the diagnostics manifest. Pass the desired ID after a double dash so Godot forwards it to the script unchanged:
+
+```bash
+godot --headless --script res://tests/run_script_diagnostic.gd -- strategy:hybrid:overlap_window
+```
+
+The example above isolates the hybrid strategy's overlap window diagnostic without replaying every manifest suite. Refer to `devdocs/tooling.md` for additional QA workflows and manifest management tips.

--- a/devdocs/tooling.md
+++ b/devdocs/tooling.md
@@ -21,3 +21,21 @@ Expected output:
 2. Parse command-line arguments with `OS.get_cmdline_args()` when you need additional parameters (such as output paths or filters).
 3. Reuse helper utilities from `name_generator/utils/` where possible to keep behaviour deterministic and testable.
 4. Document new scripts here and add usage examples to the root `README.md` to keep workflows discoverable.
+
+## Diagnostics manifest
+
+The headless diagnostic runner (`tests/run_script_diagnostic.gd`) reads from `tests/diagnostics/manifest.json`. Each manifest entry maps a stable `id` to the Godot script that exercises a focused scenario, alongside a short `summary` to help triage failures quickly. Use the colon-delimited format `domain:subject:detail` when minting IDs—e.g. `strategy:hybrid:overlap_window` evaluates the hybrid generator's overlap window safeguards.
+
+List the available IDs directly from the manifest to confirm coverage or to feed into automation:
+
+```bash
+jq -r '.diagnostics[].id + "\t" + .summary' tests/diagnostics/manifest.json
+```
+
+Automation and local scripts can invoke the runner headlessly by forwarding the chosen ID after a double dash so Godot preserves the argument:
+
+```bash
+godot --headless --script res://tests/run_script_diagnostic.gd -- strategy:hybrid:overlap_window
+```
+
+The runner exits with a non-zero status code when a diagnostic fails, making it suitable for CI pipelines or pre-commit hooks.

--- a/tests/diagnostics/README.md
+++ b/tests/diagnostics/README.md
@@ -1,0 +1,15 @@
+# Diagnostics Catalog
+
+The diagnostic manifest stored alongside this README defines scripted scenarios that highlight specific behaviours or guardrails in the name generator stack.
+
+## Naming conventions
+
+- **IDs** follow the `domain:subject:detail` format. Use descriptive nouns so downstream tooling can group related diagnostics (for example, `strategy:hybrid:overlap_window`).
+- **Scripts** live under `tests/diagnostics/` and are named after their ID with underscores instead of colons (e.g. `strategy_hybrid_overlap_window.gd`).
+- **Summaries** in the manifest should fit on a single line and explain why the diagnostic exists or what regression it catches.
+
+## Expectations for new diagnostics
+
+1. Implement the scenario as a standalone Godot script that exits via `quit()` and raises `push_error()` when validation fails.
+2. Register the script in `manifest.json` with a unique ID, matching summary, and optional `tags` array if automation needs to filter the suite.
+3. Update `devdocs/tooling.md` and other relevant guides when introducing new diagnostics so integrators understand how to trigger them.


### PR DESCRIPTION
## Summary
- explain how to trigger the headless diagnostic runner from the main README
- document the diagnostics manifest layout, naming conventions, and automation entry point in tooling docs
- add guidance in tests/diagnostics/README.md for organising future diagnostic scripts and IDs

## Testing
- godot --version (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68caf88788d483209566da32faf64da9