### PR TITLE
Add template strategy diagnostic coverage

### DIFF
--- a/tests/diagnostics/template_strategy_diagnostic.gd
+++ b/tests/diagnostics/template_strategy_diagnostic.gd
@@ -54,7 +54,7 @@ func run() -> Dictionary:
 
     _record("template_expansion", func(): return _test_template_expansion())
     _record("occurrence_specific_seeding", func(): return _test_occurrence_specific_seeding())
-    _record("recursion_depth_enforcement", func(): return _test_recursion_depth_enforcement())
+    _record("error_template_recursion_depth_exceeded", func(): return _test_recursion_depth_enforcement())
     _record("error_invalid_template_type", func(): return _test_invalid_template_type())
     _record("error_invalid_sub_generators_type", func(): return _test_invalid_sub_generators_type())
     _record("error_missing_template_token", func(): return _test_missing_template_token())

--- a/tests/script_diagnostics_manifest.json
+++ b/tests/script_diagnostics_manifest.json
@@ -7,6 +7,7 @@
     "name_generator_rng_manager": "res://tests/diagnostics/name_generator_rng_manager_diagnostic.gd",
     "rng_stream_router": "res://tests/diagnostics/rng_stream_router_diagnostic.gd",
     "rng_processor": "res://tests/diagnostics/rng_processor_diagnostic.gd",
+    "template_strategy": "res://tests/diagnostics/template_strategy_diagnostic.gd",
     "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd"
   }
 }


### PR DESCRIPTION
## Summary
- add a deterministic diagnostic for TemplateStrategy exercising expansion, seeding, recursion guards, and validation errors
- register the new diagnostic in the scripted manifest

## Testing
- attempted `godot --headless --script res://tests/run_script_diagnostic.gd --diagnostic-id template_strategy` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb013500cc8320991dffc084181ce1