### PR TITLE
Add reusable RNGProcessor headless scenarios and diagnostic

### DIFF
--- a/tests/diagnostics/rng_processor_headless_diagnostic.gd
+++ b/tests/diagnostics/rng_processor_headless_diagnostic.gd
@@ -1,0 +1,92 @@
+extends RefCounted
+
+const RNGProcessor := preload("res://name_generator/RNGProcessor.gd")
+const DebugRNG := preload("res://name_generator/tools/DebugRNG.gd")
+const ScenarioHelper := preload("res://tests/helpers/rng_processor_scenarios.gd")
+
+const DEBUG_LOG_PATH := "user://debug_rng_processor_headless.txt"
+
+func run() -> Dictionary:
+    var processor := RNGProcessor.new()
+    processor._ready()
+
+    var debug_rng := DebugRNG.new()
+    debug_rng.begin_session({
+        "suite": "rng_processor_headless",
+    })
+    debug_rng.attach_to_processor(processor, DEBUG_LOG_PATH)
+
+    var started_events: Array[Dictionary] = []
+    var completed_events: Array[Dictionary] = []
+    var failed_events: Array[Dictionary] = []
+
+    processor.connect("generation_started", Callable(self, "_capture_started").bind(started_events))
+    processor.connect("generation_completed", Callable(self, "_capture_completed").bind(completed_events))
+    processor.connect("generation_failed", Callable(self, "_capture_failed").bind(failed_events))
+
+    processor.initialize_master_seed(424242)
+    debug_rng.record_warning("Headless RNGProcessor scenarios starting.", {"suite": "rng_processor_headless"})
+
+    var failures: Array[Dictionary] = []
+    var scenarios := ScenarioHelper.collect_default_scenarios(processor)
+    for scenario in scenarios:
+        var scenario_name := String(scenario.get("name", ""))
+        var scenario_callable := scenario.get("callable")
+        if scenario_callable is Callable:
+            var message := scenario_callable.call()
+            if message != null:
+                failures.append({
+                    "name": scenario_name,
+                    "message": String(message),
+                })
+        else:
+            failures.append({
+                "name": scenario_name if not scenario_name.is_empty() else "invalid_scenario_callable",
+                "message": "Scenario helper returned a non-callable entry.",
+            })
+
+    debug_rng.record_warning("Headless RNGProcessor scenarios completed.", {"suite": "rng_processor_headless"})
+    debug_rng.close()
+
+    failures += ScenarioHelper.evaluate_signal_counts(started_events, completed_events, failed_events)
+    failures += ScenarioHelper.evaluate_debug_log(DEBUG_LOG_PATH)
+
+    var scenario_checks := scenarios.size()
+    var signal_checks := ScenarioHelper.expected_signal_counts().keys().size()
+    var debug_markers := ScenarioHelper.debug_log_markers()
+    var debug_checks := 2 + debug_markers.size()  # existence + open + markers
+    var total_checks := scenario_checks + signal_checks + debug_checks
+    var failed := failures.size()
+    var passed := max(total_checks - failed, 0)
+
+    processor.free()
+
+    return {
+        "id": "rng_processor_headless",
+        "name": "RNGProcessor Headless Diagnostic",
+        "suite": "rng_processor_headless",
+        "total": total_checks,
+        "passed": passed,
+        "failed": failed,
+        "failures": failures.duplicate(true),
+    }
+
+func _capture_started(config: Dictionary, metadata: Dictionary, bucket: Array) -> void:
+    bucket.append({
+        "config": config.duplicate(true),
+        "metadata": metadata.duplicate(true),
+    })
+
+func _capture_completed(config: Dictionary, result: Variant, metadata: Dictionary, bucket: Array) -> void:
+    bucket.append({
+        "config": config.duplicate(true),
+        "metadata": metadata.duplicate(true),
+        "result": result,
+    })
+
+func _capture_failed(config: Dictionary, error: Dictionary, metadata: Dictionary, bucket: Array) -> void:
+    bucket.append({
+        "config": config.duplicate(true),
+        "metadata": metadata.duplicate(true),
+        "error": error.duplicate(true),
+    })

--- a/tests/helpers/rng_processor_scenarios.gd
+++ b/tests/helpers/rng_processor_scenarios.gd
@@ -1,0 +1,281 @@
+extends RefCounted
+
+## Shared RNGProcessor headless scenarios used by both the legacy SceneTree-based
+## integration test and the single-script diagnostic harness. The helper keeps
+## scenario configuration data and validation logic in one place so changes to
+## expected behaviour remain consistent across both entry points.
+
+const NameGeneratorScript := preload("res://name_generator/NameGenerator.gd")
+
+const WORDLIST_PATH := "res://tests/test_assets/wordlist_basic.tres"
+const SYLLABLE_PATH := "res://tests/test_assets/syllable_basic.tres"
+const MARKOV_PATH := "res://tests/test_assets/markov_basic.tres"
+
+static func collect_default_scenarios(processor: RNGProcessor) -> Array[Dictionary]:
+    ## Build the canonical list of deterministic scenarios exercised by the
+    ## headless suite. Each entry exposes a `name` identifier paired with a
+    ## callable that returns `null` on success or an error string describing the
+    ## failure context.
+    return [
+        _scenario_entry("wordlist_deterministic", func(): return scenario_wordlist(processor)),
+        _scenario_entry("syllable_deterministic", func(): return scenario_syllable(processor)),
+        _scenario_entry("markov_deterministic", func(): return scenario_markov(processor)),
+        _scenario_entry("hybrid_deterministic", func(): return scenario_hybrid(processor)),
+        _scenario_entry("missing_wordlist_paths", func(): return scenario_missing_wordlist(processor)),
+        _scenario_entry("unknown_strategy_error", func(): return scenario_unknown_strategy(processor)),
+    ]
+
+static func scenario_wordlist(processor: RNGProcessor) -> Variant:
+    var config := {
+        "strategy": "wordlist",
+        "wordlist_paths": [WORDLIST_PATH],
+        "use_weights": true,
+        "seed": "headless_wordlist",
+    }
+    return _validate_successful_result(processor, config, "wordlist")["message"]
+
+static func scenario_syllable(processor: RNGProcessor) -> Variant:
+    var config := {
+        "strategy": "syllable",
+        "syllable_set_path": SYLLABLE_PATH,
+        "seed": "headless_syllable",
+        "require_middle": false,
+    }
+    return _validate_successful_result(processor, config, "syllable")["message"]
+
+static func scenario_markov(processor: RNGProcessor) -> Variant:
+    var config := {
+        "strategy": "markov",
+        "markov_model_path": MARKOV_PATH,
+        "seed": "headless_markov",
+    }
+    return _validate_successful_result(processor, config, "markov")["message"]
+
+static func scenario_hybrid(processor: RNGProcessor) -> Variant:
+    var config := {
+        "strategy": "hybrid",
+        "seed": "headless_hybrid",
+        "steps": [
+            {
+                "strategy": "wordlist",
+                "wordlist_paths": [WORDLIST_PATH],
+                "use_weights": true,
+                "store_as": "title",
+            },
+            {
+                "strategy": "markov",
+                "markov_model_path": MARKOV_PATH,
+                "store_as": "root",
+            },
+            {
+                "strategy": "syllable",
+                "syllable_set_path": SYLLABLE_PATH,
+                "store_as": "suffix",
+            },
+        ],
+        "template": "$title $root$suffix",
+    }
+
+    var evaluation := _validate_successful_result(processor, config, "hybrid")
+    var message := evaluation.get("message", null)
+    if message != null:
+        return message
+
+    var result_text := String(evaluation.get("result", ""))
+    if result_text.find("$") != -1:
+        return "Hybrid template placeholders should be resolved in the final output."
+
+    return null
+
+static func scenario_missing_wordlist(processor: RNGProcessor) -> Variant:
+    var config := {
+        "strategy": "wordlist",
+        "wordlist_paths": [],
+        "seed": "headless_missing_wordlist",
+    }
+
+    var result := processor.generate(config)
+    if not (result is Dictionary):
+        return "Missing wordlist configuration should surface an error dictionary."
+
+    var error := result as Dictionary
+    if error.get("code", "") != "wordlists_missing":
+        return "Unexpected error code for missing wordlist paths: %s" % error.get("code", "")
+
+    if not error.has("message") or String(error.get("message", "")).is_empty():
+        return "Error dictionary must include a descriptive message."
+
+    if not error.has("details") or typeof(error["details"]) != TYPE_DICTIONARY:
+        return "Error dictionary must include a details payload."
+
+    return null
+
+static func scenario_unknown_strategy(processor: RNGProcessor) -> Variant:
+    var config := {
+        "strategy": "does_not_exist",
+        "seed": "headless_unknown_strategy",
+    }
+
+    var result := processor.generate(config)
+    if not (result is Dictionary):
+        return "Unknown strategy configuration should surface an error dictionary."
+
+    var error := result as Dictionary
+    if error.get("code", "") != "unknown_strategy":
+        return "Unexpected error code for unknown strategy: %s" % error.get("code", "")
+
+    if not error.has("message") or String(error.get("message", "")).is_empty():
+        return "Unknown strategy error should provide a message."
+
+    return null
+
+static func expected_signal_counts() -> Dictionary:
+    return {
+        "started": 6,
+        "completed": 4,
+        "failed": 2,
+    }
+
+static func debug_log_markers() -> PackedStringArray:
+    var markers := PackedStringArray()
+    markers.append("wordlist::headless_wordlist")
+    markers.append("syllable::headless_syllable")
+    markers.append("markov::headless_markov")
+    markers.append("hybrid::headless_hybrid")
+    markers.append("does_not_exist::headless_unknown_strategy")
+    return markers
+
+static func evaluate_signal_counts(
+    started_events: Array,
+    completed_events: Array,
+    failed_events: Array
+) -> Array[Dictionary]:
+    var failures: Array[Dictionary] = []
+    var expectations := expected_signal_counts()
+
+    var expected_started := int(expectations.get("started", 0))
+    if started_events.size() != expected_started:
+        failures.append({
+            "name": "signal_started_count",
+            "message": "Expected %d generation_started events, observed %d." % [expected_started, started_events.size()],
+        })
+
+    var expected_completed := int(expectations.get("completed", 0))
+    if completed_events.size() != expected_completed:
+        failures.append({
+            "name": "signal_completed_count",
+            "message": "Expected %d generation_completed events, observed %d." % [expected_completed, completed_events.size()],
+        })
+
+    var expected_failed := int(expectations.get("failed", 0))
+    if failed_events.size() != expected_failed:
+        failures.append({
+            "name": "signal_failed_count",
+            "message": "Expected %d generation_failed events, observed %d." % [expected_failed, failed_events.size()],
+        })
+
+    return failures
+
+static func evaluate_debug_log(report_path: String, markers: PackedStringArray = PackedStringArray()) -> Array[Dictionary]:
+    var failures: Array[Dictionary] = []
+    var expected_markers := markers if markers.size() > 0 else debug_log_markers()
+
+    if not FileAccess.file_exists(report_path):
+        failures.append({
+            "name": "debug_log_exists",
+            "message": "DebugRNG log was not written to %s" % report_path,
+        })
+        return failures
+
+    var file := FileAccess.open(report_path, FileAccess.READ)
+    if file == null:
+        failures.append({
+            "name": "debug_log_open",
+            "message": "Unable to open DebugRNG log at %s" % report_path,
+        })
+        return failures
+
+    var report := file.get_as_text()
+    for marker in expected_markers:
+        if report.find(marker) == -1:
+            failures.append({
+                "name": "debug_log_marker_%s" % marker,
+                "message": "DebugRNG report missing marker '%s'." % marker,
+            })
+
+    return failures
+
+static func expected_string(processor: RNGProcessor, config: Dictionary) -> Variant:
+    var expected := _generate_expected_payload(processor, config)
+    if expected is Dictionary:
+        return expected
+    return String(expected)
+
+static func _generate_expected_payload(processor: RNGProcessor, config: Dictionary) -> Variant:
+    var generator := Engine.get_singleton("NameGenerator")
+    if generator == null:
+        return {"code": "missing_name_generator"}
+
+    var strategy_id := String(config.get("strategy", "")).strip_edges()
+    var stream_name := _derive_stream_name(config, strategy_id)
+    var clone := _clone_stream_rng(processor, stream_name)
+
+    var duplicate_config := config.duplicate(true)
+    return generator.generate(duplicate_config, clone)
+
+static func _derive_stream_name(config: Dictionary, strategy_id: String) -> String:
+    if config.has("rng_stream"):
+        return String(config["rng_stream"])
+
+    if config.has("seed"):
+        var seed_string := String(config["seed"]).strip_edges()
+        if seed_string.is_empty():
+            seed_string = "seed"
+        return "%s::%s" % [strategy_id, seed_string]
+
+    return "%s::%s" % [NameGeneratorScript.DEFAULT_STREAM_PREFIX, strategy_id]
+
+static func _clone_stream_rng(processor: RNGProcessor, stream_name: String) -> RandomNumberGenerator:
+    var source := processor.get_rng(stream_name)
+    var clone := RandomNumberGenerator.new()
+    clone.seed = source.seed
+    clone.state = source.state
+    return clone
+
+static func _scenario_entry(name: String, callable: Callable) -> Dictionary:
+    return {
+        "name": name,
+        "callable": callable,
+    }
+
+static func _validate_successful_result(processor: RNGProcessor, config: Dictionary, label: String) -> Dictionary:
+    var expected := expected_string(processor, config)
+    if expected is Dictionary:
+        return {
+            "message": "Expected NameGenerator to succeed for %s scenario: %s" % [label, (expected as Dictionary).get("code", "")],
+            "result": null,
+            "expected": expected,
+        }
+
+    var expected_text := String(expected)
+    var result := processor.generate(config)
+    if result is Dictionary:
+        return {
+            "message": "%s configuration should succeed but returned error code %s" % [label.capitalize(), (result as Dictionary).get("code", "")],
+            "result": result,
+            "expected": expected_text,
+        }
+
+    var result_text := String(result)
+    if result_text != expected_text:
+        return {
+            "message": "%s result mismatch. Expected '%s' but received '%s'." % [label.capitalize(), expected_text, result_text],
+            "result": result,
+            "expected": expected_text,
+        }
+
+    return {
+        "message": null,
+        "result": result,
+        "expected": expected_text,
+    }

--- a/tests/script_diagnostics_manifest.json
+++ b/tests/script_diagnostics_manifest.json
@@ -6,10 +6,10 @@
     "name_generator": "res://tests/diagnostics/name_generator_diagnostic.gd",
     "name_generator_rng_manager": "res://tests/diagnostics/name_generator_rng_manager_diagnostic.gd",
     "rng_processor": "res://tests/diagnostics/rng_processor_diagnostic.gd",
-    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd"
+    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd",
     "rng_stream_router": "res://tests/diagnostics/rng_stream_router_diagnostic.gd",
     "template_strategy": "res://tests/diagnostics/template_strategy_diagnostic.gd",
-    "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd"
-
+    "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd",
+    "rng_processor_headless": "res://tests/diagnostics/rng_processor_headless_diagnostic.gd"
   }
 }

--- a/tests/test_rng_processor_headless.gd
+++ b/tests/test_rng_processor_headless.gd
@@ -2,11 +2,8 @@ extends SceneTree
 
 const RNGProcessor := preload("res://name_generator/RNGProcessor.gd")
 const DebugRNG := preload("res://name_generator/tools/DebugRNG.gd")
-const NameGeneratorScript := preload("res://name_generator/NameGenerator.gd")
+const ScenarioHelper := preload("res://tests/helpers/rng_processor_scenarios.gd")
 
-const WORDLIST_PATH := "res://tests/test_assets/wordlist_basic.tres"
-const SYLLABLE_PATH := "res://tests/test_assets/syllable_basic.tres"
-const MARKOV_PATH := "res://tests/test_assets/markov_basic.tres"
 const DEBUG_LOG_PATH := "user://debug_rng_processor_headless.txt"
 
 var _processor: RNGProcessor
@@ -38,18 +35,22 @@ func _run() -> void:
     _processor.initialize_master_seed(424242)
     _debug_rng.record_warning("Headless RNGProcessor scenarios starting.", {"suite": "rng_processor_headless"})
 
-    _execute("wordlist_deterministic", func(): return _scenario_wordlist())
-    _execute("syllable_deterministic", func(): return _scenario_syllable())
-    _execute("markov_deterministic", func(): return _scenario_markov())
-    _execute("hybrid_deterministic", func(): return _scenario_hybrid())
-    _execute("missing_wordlist_paths", func(): return _scenario_missing_wordlist())
-    _execute("unknown_strategy_error", func(): return _scenario_unknown_strategy())
+    for scenario in ScenarioHelper.collect_default_scenarios(_processor):
+        var scenario_name := String(scenario.get("name", ""))
+        var scenario_callable := scenario.get("callable")
+        if scenario_callable is Callable:
+            _execute(scenario_name, scenario_callable)
+        else:
+            _failures.append({
+                "name": scenario_name if not scenario_name.is_empty() else "invalid_scenario_callable",
+                "message": "Scenario helper returned a non-callable entry.",
+            })
 
     _debug_rng.record_warning("Headless RNGProcessor scenarios completed.", {"suite": "rng_processor_headless"})
     _debug_rng.close()
 
-    _verify_signal_counts()
-    _verify_debug_log()
+    _append_failures(ScenarioHelper.evaluate_signal_counts(_started_events, _completed_events, _failed_events))
+    _append_failures(ScenarioHelper.evaluate_debug_log(DEBUG_LOG_PATH))
 
     var exit_code = 0 if _failures.is_empty() else 1
     if exit_code != 0:
@@ -69,242 +70,9 @@ func _execute(name: String, callable: Callable) -> void:
         "message": String(message),
     })
 
-func _scenario_wordlist() -> Variant:
-    var config = {
-        "strategy": "wordlist",
-        "wordlist_paths": [WORDLIST_PATH],
-        "use_weights": true,
-        "seed": "headless_wordlist",
-    }
-
-    var expected = _expected_string(config)
-    if expected is Dictionary:
-        return "Expected NameGenerator to succeed for wordlist scenario: %s" % (expected as Dictionary).get("code", "")
-
-    var result = _processor.generate(config)
-    if result is Dictionary:
-        return "Wordlist configuration should succeed but returned error code %s" % (result as Dictionary).get("code", "")
-
-    if String(result) != String(expected):
-        return "Wordlist result mismatch. Expected '%s' but received '%s'." % [expected, result]
-
-    return null
-
-func _scenario_syllable() -> Variant:
-    var config = {
-        "strategy": "syllable",
-        "syllable_set_path": SYLLABLE_PATH,
-        "seed": "headless_syllable",
-        "require_middle": false,
-    }
-
-    var expected = _expected_string(config)
-    if expected is Dictionary:
-        return "Expected NameGenerator to succeed for syllable scenario: %s" % (expected as Dictionary).get("code", "")
-
-    var result = _processor.generate(config)
-    if result is Dictionary:
-        return "Syllable configuration should succeed but returned error code %s" % (result as Dictionary).get("code", "")
-
-    if String(result) != String(expected):
-        return "Syllable result mismatch. Expected '%s' but received '%s'." % [expected, result]
-
-    return null
-
-func _scenario_markov() -> Variant:
-    var config = {
-        "strategy": "markov",
-        "markov_model_path": MARKOV_PATH,
-        "seed": "headless_markov",
-    }
-
-    var expected = _expected_string(config)
-    if expected is Dictionary:
-        return "Expected NameGenerator to succeed for markov scenario: %s" % (expected as Dictionary).get("code", "")
-
-    var result = _processor.generate(config)
-    if result is Dictionary:
-        return "Markov configuration should succeed but returned error code %s" % (result as Dictionary).get("code", "")
-
-    if String(result) != String(expected):
-        return "Markov result mismatch. Expected '%s' but received '%s'." % [expected, result]
-
-    return null
-
-func _scenario_hybrid() -> Variant:
-    var config = {
-        "strategy": "hybrid",
-        "seed": "headless_hybrid",
-        "steps": [
-            {
-                "strategy": "wordlist",
-                "wordlist_paths": [WORDLIST_PATH],
-                "use_weights": true,
-                "store_as": "title",
-            },
-            {
-                "strategy": "markov",
-                "markov_model_path": MARKOV_PATH,
-                "store_as": "root",
-            },
-            {
-                "strategy": "syllable",
-                "syllable_set_path": SYLLABLE_PATH,
-                "store_as": "suffix",
-            },
-        ],
-        "template": "$title $root$suffix",
-    }
-
-    var expected = _expected_string(config)
-    if expected is Dictionary:
-        return "Expected NameGenerator to succeed for hybrid scenario: %s" % (expected as Dictionary).get("code", "")
-
-    var result = _processor.generate(config)
-    if result is Dictionary:
-        return "Hybrid configuration should succeed but returned error code %s" % (result as Dictionary).get("code", "")
-
-    if String(result) != String(expected):
-        return "Hybrid result mismatch. Expected '%s' but received '%s'." % [expected, result]
-
-    if String(result).find("$") != -1:
-        return "Hybrid template placeholders should be resolved in the final output."
-
-    return null
-
-func _scenario_missing_wordlist() -> Variant:
-    var config = {
-        "strategy": "wordlist",
-        "wordlist_paths": [],
-        "seed": "headless_missing_wordlist",
-    }
-
-    var result = _processor.generate(config)
-    if not (result is Dictionary):
-        return "Missing wordlist configuration should surface an error dictionary."
-
-    var error = result as Dictionary
-    if error.get("code", "") != "wordlists_missing":
-        return "Unexpected error code for missing wordlist paths: %s" % error.get("code", "")
-
-    if not error.has("message") or String(error.get("message", "")).is_empty():
-        return "Error dictionary must include a descriptive message."
-
-    if not error.has("details") or typeof(error["details"]) != TYPE_DICTIONARY:
-        return "Error dictionary must include a details payload."
-
-    return null
-
-func _scenario_unknown_strategy() -> Variant:
-    var config = {
-        "strategy": "does_not_exist",
-        "seed": "headless_unknown_strategy",
-    }
-
-    var result = _processor.generate(config)
-    if not (result is Dictionary):
-        return "Unknown strategy configuration should surface an error dictionary."
-
-    var error = result as Dictionary
-    if error.get("code", "") != "unknown_strategy":
-        return "Unexpected error code for unknown strategy: %s" % error.get("code", "")
-
-    if not error.has("message") or String(error.get("message", "")).is_empty():
-        return "Unknown strategy error should provide a message."
-
-    return null
-
-func _expected_string(config: Dictionary) -> Variant:
-    var expected = _generate_expected_payload(config)
-    if expected is Dictionary:
-        return expected
-    return String(expected)
-
-func _generate_expected_payload(config: Dictionary) -> Variant:
-    var generator = Engine.get_singleton("NameGenerator")
-    if generator == null:
-        return {"code": "missing_name_generator"}
-
-    var strategy_id = String(config.get("strategy", "")).strip_edges()
-    var stream_name = _derive_stream_name(config, strategy_id)
-    var clone = _clone_stream_rng(stream_name)
-
-    var duplicate_config = config.duplicate(true)
-    return generator.generate(duplicate_config, clone)
-
-func _derive_stream_name(config: Dictionary, strategy_id: String) -> String:
-    if config.has("rng_stream"):
-        return String(config["rng_stream"])
-
-    if config.has("seed"):
-        var seed_string = String(config["seed"]).strip_edges()
-        if seed_string.is_empty():
-            seed_string = "seed"
-        return "%s::%s" % [strategy_id, seed_string]
-
-    return "%s::%s" % [NameGeneratorScript.DEFAULT_STREAM_PREFIX, strategy_id]
-
-func _clone_stream_rng(stream_name: String) -> RandomNumberGenerator:
-    var source = _processor.get_rng(stream_name)
-    var clone = RandomNumberGenerator.new()
-    clone.seed = source.seed
-    clone.state = source.state
-    return clone
-
-func _verify_signal_counts() -> void:
-    var expected_started = 6
-    var expected_completed = 4
-    var expected_failed = 2
-
-    if _started_events.size() != expected_started:
-        _failures.append({
-            "name": "signal_started_count",
-            "message": "Expected %d generation_started events, observed %d." % [expected_started, _started_events.size()],
-        })
-
-    if _completed_events.size() != expected_completed:
-        _failures.append({
-            "name": "signal_completed_count",
-            "message": "Expected %d generation_completed events, observed %d." % [expected_completed, _completed_events.size()],
-        })
-
-    if _failed_events.size() != expected_failed:
-        _failures.append({
-            "name": "signal_failed_count",
-            "message": "Expected %d generation_failed events, observed %d." % [expected_failed, _failed_events.size()],
-        })
-
-func _verify_debug_log() -> void:
-    if not FileAccess.file_exists(DEBUG_LOG_PATH):
-        _failures.append({
-            "name": "debug_log_exists",
-            "message": "DebugRNG log was not written to %s" % DEBUG_LOG_PATH,
-        })
-        return
-
-    var file = FileAccess.open(DEBUG_LOG_PATH, FileAccess.READ)
-    if file == null:
-        _failures.append({
-            "name": "debug_log_open",
-            "message": "Unable to open DebugRNG log at %s" % DEBUG_LOG_PATH,
-        })
-        return
-
-    var report = file.get_as_text()
-    var markers = [
-        "wordlist::headless_wordlist",
-        "syllable::headless_syllable",
-        "markov::headless_markov",
-        "hybrid::headless_hybrid",
-        "does_not_exist::headless_unknown_strategy",
-    ]
-
-    for marker in markers:
-        if report.find(marker) == -1:
-            _failures.append({
-                "name": "debug_log_marker_%s" % marker,
-                "message": "DebugRNG report missing marker '%s'." % marker,
-            })
+func _append_failures(failures: Array[Dictionary]) -> void:
+    for failure in failures:
+        _failures.append(failure.duplicate(true))
 
 func _on_generation_started(config: Dictionary, metadata: Dictionary) -> void:
     _started_events.append({


### PR DESCRIPTION
## Summary
- extract the RNGProcessor headless scenario and validation logic into a reusable helper
- update the headless SceneTree test to leverage the shared helper utilities
- add a single-script diagnostic that reuses the scenarios and register it in the manifest

## Testing
- Unable to run `godot --headless --script res://tests/test_rng_processor_headless.gd` (godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb02fcd0d083208c3f5f70059b0761