### PR TITLE
Add diagnostics wrappers for legacy name generator tests

### DIFF
--- a/tests/diagnostics/legacy_test_debug_rng_diagnostic.gd
+++ b/tests/diagnostics/legacy_test_debug_rng_diagnostic.gd
@@ -1,0 +1,30 @@
+extends RefCounted
+
+const DebugRNGTests := preload("res://name_generator/tests/test_debug_rng.gd")
+
+func run() -> Dictionary:
+    var test_instance := DebugRNGTests.new()
+    var result: Dictionary = test_instance.run()
+
+    var total := int(result.get("total", 0))
+    var passed := int(result.get("passed", 0))
+    var failed := int(result.get("failed", 0))
+    var failures := result.get("failures", [])
+    if failures is Array:
+        failures = failures.duplicate(true)
+    else:
+        failures = []
+
+    var diagnostic := {
+        "id": "legacy_test_debug_rng",
+        "name": "Legacy Debug RNG test suite",
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "failures": failures,
+    }
+
+    if result.has("suite"):
+        diagnostic["suite"] = result["suite"]
+
+    return diagnostic

--- a/tests/diagnostics/legacy_test_generator_strategy_diagnostic.gd
+++ b/tests/diagnostics/legacy_test_generator_strategy_diagnostic.gd
@@ -1,0 +1,30 @@
+extends RefCounted
+
+const GeneratorStrategyTests := preload("res://name_generator/tests/test_generator_strategy.gd")
+
+func run() -> Dictionary:
+    var test_instance := GeneratorStrategyTests.new()
+    var result: Dictionary = test_instance.run()
+
+    var total := int(result.get("total", 0))
+    var passed := int(result.get("passed", 0))
+    var failed := int(result.get("failed", 0))
+    var failures := result.get("failures", [])
+    if failures is Array:
+        failures = failures.duplicate(true)
+    else:
+        failures = []
+
+    var diagnostic := {
+        "id": "legacy_test_generator_strategy",
+        "name": "Legacy generator strategy test suite",
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "failures": failures,
+    }
+
+    if result.has("suite"):
+        diagnostic["suite"] = result["suite"]
+
+    return diagnostic

--- a/tests/diagnostics/legacy_test_hybrid_strategy_diagnostic.gd
+++ b/tests/diagnostics/legacy_test_hybrid_strategy_diagnostic.gd
@@ -1,0 +1,30 @@
+extends RefCounted
+
+const HybridStrategyTests := preload("res://name_generator/tests/test_hybrid_strategy.gd")
+
+func run() -> Dictionary:
+    var test_instance := HybridStrategyTests.new()
+    var result: Dictionary = test_instance.run()
+
+    var total := int(result.get("total", 0))
+    var passed := int(result.get("passed", 0))
+    var failed := int(result.get("failed", 0))
+    var failures := result.get("failures", [])
+    if failures is Array:
+        failures = failures.duplicate(true)
+    else:
+        failures = []
+
+    var diagnostic := {
+        "id": "legacy_test_hybrid_strategy",
+        "name": "Legacy hybrid strategy test suite",
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "failures": failures,
+    }
+
+    if result.has("suite"):
+        diagnostic["suite"] = result["suite"]
+
+    return diagnostic

--- a/tests/diagnostics/legacy_test_rng_processor_diagnostic.gd
+++ b/tests/diagnostics/legacy_test_rng_processor_diagnostic.gd
@@ -1,0 +1,30 @@
+extends RefCounted
+
+const RNGProcessorTests := preload("res://name_generator/tests/test_rng_processor.gd")
+
+func run() -> Dictionary:
+    var test_instance := RNGProcessorTests.new()
+    var result: Dictionary = test_instance.run()
+
+    var total := int(result.get("total", 0))
+    var passed := int(result.get("passed", 0))
+    var failed := int(result.get("failed", 0))
+    var failures := result.get("failures", [])
+    if failures is Array:
+        failures = failures.duplicate(true)
+    else:
+        failures = []
+
+    var diagnostic := {
+        "id": "legacy_test_rng_processor",
+        "name": "Legacy RNG processor test suite",
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "failures": failures,
+    }
+
+    if result.has("suite"):
+        diagnostic["suite"] = result["suite"]
+
+    return diagnostic

--- a/tests/script_diagnostics_manifest.json
+++ b/tests/script_diagnostics_manifest.json
@@ -2,14 +2,17 @@
   "diagnostics": {
     "autoload_rng_manager": "res://tests/diagnostics/autoload_rng_manager_diagnostic.gd",
     "debug_rng": "res://tests/diagnostics/debug_rng_diagnostic.gd",
+    "legacy_test_debug_rng": "res://tests/diagnostics/legacy_test_debug_rng_diagnostic.gd",
+    "legacy_test_generator_strategy": "res://tests/diagnostics/legacy_test_generator_strategy_diagnostic.gd",
+    "legacy_test_hybrid_strategy": "res://tests/diagnostics/legacy_test_hybrid_strategy_diagnostic.gd",
+    "legacy_test_rng_processor": "res://tests/diagnostics/legacy_test_rng_processor_diagnostic.gd",
     "manifest_self_check": "res://tests/diagnostics/manifest_self_check_diagnostic.gd",
     "name_generator": "res://tests/diagnostics/name_generator_diagnostic.gd",
     "name_generator_rng_manager": "res://tests/diagnostics/name_generator_rng_manager_diagnostic.gd",
     "rng_processor": "res://tests/diagnostics/rng_processor_diagnostic.gd",
-    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd"
     "rng_stream_router": "res://tests/diagnostics/rng_stream_router_diagnostic.gd",
+    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd",
     "template_strategy": "res://tests/diagnostics/template_strategy_diagnostic.gd",
     "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd"
-
   }
 }


### PR DESCRIPTION
## Summary
- add script diagnostics that wrap the legacy generator strategy, hybrid strategy, debug RNG, and RNG processor tests
- expose the new diagnostics through the script diagnostics manifest so they can be invoked by id

## Testing
- unable to run `godot --headless --script res://tests/run_script_diagnostic.gd -- legacy_test_generator_strategy` (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb02fd73ec832088dd62b15bf1bc7f