### PR TITLE
Fix Godot 4.4 type compatibility issues

### DIFF
--- a/name_generator/NameGenerator.gd
+++ b/name_generator/NameGenerator.gd
@@ -158,7 +158,7 @@ func _validate_request_config(config: Variant, allow_missing_seed: bool) -> Dict
             "NameGenerator.generate expects a Dictionary configuration.",
             {
                 "received_type": typeof(config),
-                "type_name": Variant.get_type_name(typeof(config)),
+                "type_name": type_string(typeof(config)),
             },
         )
 
@@ -182,7 +182,7 @@ func _validate_request_config(config: Variant, allow_missing_seed: bool) -> Dict
             "The 'rng_stream' override must be a string when provided.",
             {
                 "received_type": typeof(dictionary["rng_stream"]),
-                "type_name": Variant.get_type_name(typeof(dictionary["rng_stream"])),
+                "type_name": type_string(typeof(dictionary["rng_stream"])),
             },
         )
 
@@ -220,9 +220,9 @@ func _acquire_rng(stream_name: String) -> RandomNumberGenerator:
     if Engine.has_singleton("RNGManager"):
         var manager := Engine.get_singleton("RNGManager")
         if manager != null and manager.has_method("get_rng"):
-            var rng := manager.call("get_rng", stream_name)
-            if rng is RandomNumberGenerator:
-                return rng
+            var rng_object: Object = manager.call("get_rng", stream_name)
+            if rng_object is RandomNumberGenerator:
+                return rng_object as RandomNumberGenerator
 
     var fallback := RandomNumberGenerator.new()
     fallback.randomize()

--- a/name_generator/RNGManager.gd
+++ b/name_generator/RNGManager.gd
@@ -59,12 +59,11 @@ func load_state(payload: Variant) -> void:
     if not data.has(_STATE_STREAMS):
         return
 
-    var streams_payload := data[_STATE_STREAMS]
-    if typeof(streams_payload) != TYPE_DICTIONARY:
+    if not (data[_STATE_STREAMS] is Dictionary):
         push_warning("RNGManager.load_state streams payload must be a Dictionary.")
         return
 
-    var streams: Dictionary = streams_payload
+    var streams: Dictionary = data[_STATE_STREAMS]
     for key in streams.keys():
         var rng: RandomNumberGenerator = get_rng(String(key))
         rng.state = int(streams[key])

--- a/name_generator/strategies/GeneratorStrategy.gd
+++ b/name_generator/strategies/GeneratorStrategy.gd
@@ -38,7 +38,7 @@ func _ensure_dictionary(value: Variant, context: String = "config") -> Generator
             "%s must be provided as a Dictionary." % context,
             {
                 "received_type": typeof(value),
-                "type_name": Variant.get_type_name(typeof(value)),
+                "type_name": type_string(typeof(value)),
             },
         )
     return null
@@ -102,13 +102,13 @@ func _validate_optional_key_types(config: Dictionary) -> GeneratorError:
         if typeof(value) != expected_type:
             return _make_error(
                 "invalid_key_type",
-                "Configuration value for '%s' must be of type %s." % [key, Variant.get_type_name(expected_type)],
+                "Configuration value for '%s' must be of type %s." % [key, type_string(expected_type)],
                 {
                     "key": key,
                     "expected_type": expected_type,
-                    "expected_type_name": Variant.get_type_name(expected_type),
+                    "expected_type_name": type_string(expected_type),
                     "received_type": typeof(value),
-                    "received_type_name": Variant.get_type_name(typeof(value)),
+                    "received_type_name": type_string(typeof(value)),
                 },
             )
 

--- a/name_generator/strategies/HybridStrategy.gd
+++ b/name_generator/strategies/HybridStrategy.gd
@@ -29,7 +29,7 @@ func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
             "HybridStrategy expects 'steps' to be an Array of configuration dictionaries.",
             {
                 "received_type": typeof(steps_variant),
-                "type_name": Variant.get_type_name(typeof(steps_variant)),
+                "type_name": type_string(typeof(steps_variant)),
             },
         )
 
@@ -105,7 +105,7 @@ func _extract_step_config(entry: Dictionary) -> Variant:
                 "Hybrid step 'config' must be a Dictionary.",
                 {
                     "received_type": typeof(payload),
-                    "type_name": Variant.get_type_name(typeof(payload)),
+                    "type_name": type_string(typeof(payload)),
                 },
             )
         return (payload as Dictionary).duplicate(true)

--- a/name_generator/strategies/TemplateStrategy.gd
+++ b/name_generator/strategies/TemplateStrategy.gd
@@ -33,7 +33,7 @@ func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
             "TemplateStrategy requires 'template_string' to be a String.",
             {
                 "received_type": typeof(template_value),
-                "type_name": Variant.get_type_name(typeof(template_value)),
+                "type_name": type_string(typeof(template_value)),
             },
         )
 
@@ -46,7 +46,7 @@ func generate(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
                 "TemplateStrategy optional 'sub_generators' must be a Dictionary.",
                 {
                     "received_type": typeof(config["sub_generators"]),
-                    "type_name": Variant.get_type_name(typeof(config["sub_generators"])),
+                    "type_name": type_string(typeof(config["sub_generators"])),
                 },
             )
         sub_generators = (config["sub_generators"] as Dictionary).duplicate(true)

--- a/name_generator/tools/DebugRNG.gd
+++ b/name_generator/tools/DebugRNG.gd
@@ -120,8 +120,10 @@ func untrack_strategy(strategy: Object) -> void:
     if not _tracked_strategies.has(key):
         return
 
-    var metadata := _tracked_strategies[key]
+    var raw_metadata := _tracked_strategies[key]
     _tracked_strategies.erase(key)
+
+    var metadata: Dictionary = raw_metadata if raw_metadata is Dictionary else {}
 
     if strategy.has_signal("generation_error"):
         var callable := Callable(self, "_on_strategy_error").bind(metadata.get("id", ""))
@@ -131,11 +133,12 @@ func untrack_strategy(strategy: Object) -> void:
 func clear_tracked_strategies() -> void:
     ## Disconnect from every tracked strategy.
     for entry in _tracked_strategies.values():
-        var strategy := entry.get("strategy", null)
-        if strategy != null and is_instance_valid(strategy):
-            var callable := Callable(self, "_on_strategy_error").bind(entry.get("id", ""))
-            if strategy.has_signal("generation_error") and strategy.is_connected("generation_error", callable):
-                strategy.disconnect("generation_error", callable)
+        var metadata: Dictionary = entry if entry is Dictionary else {}
+        var tracked_strategy: Object = metadata.get("strategy", null)
+        if tracked_strategy != null and is_instance_valid(tracked_strategy):
+            var callable := Callable(self, "_on_strategy_error").bind(metadata.get("id", ""))
+            if tracked_strategy.has_signal("generation_error") and tracked_strategy.is_connected("generation_error", callable):
+                tracked_strategy.disconnect("generation_error", callable)
     _tracked_strategies.clear()
 
 func record_warning(message: String, context: Dictionary = {}) -> void:

--- a/tests/diagnostics/generator_strategy_base_diagnostic.gd
+++ b/tests/diagnostics/generator_strategy_base_diagnostic.gd
@@ -66,8 +66,8 @@ func _test_ensure_dictionary_rejects_non_dictionary() -> Variant:
         return "Error details must be a dictionary."
     if details.get("received_type", -1) != TYPE_INT:
         return "Expected received_type TYPE_INT but received %s." % details.get("received_type")
-    if details.get("type_name", "") != Variant.get_type_name(TYPE_INT):
-        return "Expected type_name %s but received %s." % [Variant.get_type_name(TYPE_INT), details.get("type_name")]
+    if details.get("type_name", "") != type_string(TYPE_INT):
+        return "Expected type_name %s but received %s." % [type_string(TYPE_INT), details.get("type_name")]
     return null
 
 func _test_validate_required_keys_reports_missing() -> Variant:
@@ -103,7 +103,7 @@ func _test_validate_optional_key_types_enforces_types() -> Variant:
         return "_validate_optional_key_types should reject mismatched types."
     if error.code != "invalid_key_type":
         return "Expected invalid_key_type code but received %s." % error.code
-    var expected_message := "Configuration value for 'retries' must be of type %s." % Variant.get_type_name(TYPE_INT)
+    var expected_message := "Configuration value for 'retries' must be of type %s." % type_string(TYPE_INT)
     if error.message != expected_message:
         return "Expected message '%s' but received '%s'." % [expected_message, error.message]
     var details := error.details
@@ -113,11 +113,11 @@ func _test_validate_optional_key_types_enforces_types() -> Variant:
         return "Detail payload should echo the offending key."
     if details.get("expected_type", -1) != TYPE_INT:
         return "Detail payload should expose the expected Variant type."
-    if details.get("expected_type_name", "") != Variant.get_type_name(TYPE_INT):
+    if details.get("expected_type_name", "") != type_string(TYPE_INT):
         return "Detail payload should expose the expected type name."
     if details.get("received_type", -1) != TYPE_STRING:
         return "Detail payload should expose the received Variant type."
-    if details.get("received_type_name", "") != Variant.get_type_name(TYPE_STRING):
+    if details.get("received_type_name", "") != type_string(TYPE_STRING):
         return "Detail payload should expose the received type name."
     return null
 


### PR DESCRIPTION
## Summary
- replace usages of Variant.get_type_name with type_string to match Godot 4.4 APIs
- tighten Godot autoload helpers to avoid Variant inference errors when checking RNG state payloads
- harden DebugRNG cleanup to guard against non-dictionary metadata when disconnecting strategies
- ensure NameGenerator resolves RNG singletons through an Object-typed call before casting to RandomNumberGenerator

## Testing
- not run (Godot CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cb2c78fa58832094c7561e7d5ab066