### PR TITLE
Fix circular preloads for name generator strategies

### DIFF
--- a/name_generator/tools/DebugRNG.gd
+++ b/name_generator/tools/DebugRNG.gd
@@ -120,7 +120,7 @@ func untrack_strategy(strategy: Object) -> void:
     if not _tracked_strategies.has(key):
         return
 
-    var raw_metadata := _tracked_strategies[key]
+    var raw_metadata: Variant = _tracked_strategies[key]
     _tracked_strategies.erase(key)
 
     var metadata: Dictionary = raw_metadata if raw_metadata is Dictionary else {}


### PR DESCRIPTION
## Summary
- resolve the TemplateStrategy and HybridStrategy dependencies on NameGenerator by lazily resolving the autoload and caching a script fallback
- add defensive error reporting that documents the required NameGenerator resource path for misconfigured projects
- annotate DebugRNG tracking metadata to keep type inference stable after the strategy refactor

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: `godot` CLI is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2e422fd48320bda5035eca15caca