### PR TITLE
Add helper for GDScript parse errors and fix issues

### DIFF
--- a/name_generator/strategies/SyllableChainStrategy.gd
+++ b/name_generator/strategies/SyllableChainStrategy.gd
@@ -155,8 +155,12 @@ func _parse_middle_range(
     var require_middle := config.get("require_middle", false)
     var range_config := config.get("middle_syllables", null)
 
-    var min_count := require_middle ? 1 : 0
-    var max_count := require_middle ? max(1, min_count) : max(min_count, 1)
+    var min_count := 0
+    var max_count := max(min_count, 1)
+
+    if require_middle:
+        min_count = 1
+        max_count = max(1, min_count)
 
     if not syllable_set.middles.is_empty():
         max_count = max(max_count, syllable_set.middles.size())

--- a/name_generator/tests/test_debug_rng.gd
+++ b/name_generator/tests/test_debug_rng.gd
@@ -142,4 +142,3 @@ func _remove_file(path: String) -> void:
     if not FileAccess.file_exists(path):
         return
     DirAccess.remove_absolute(path)
-*** End Patch

--- a/name_generator/tools/SyllableSetBuilder.gd
+++ b/name_generator/tools/SyllableSetBuilder.gd
@@ -96,13 +96,17 @@ func _build_dock() -> Control:
     return panel
 
 func _build_instruction_text() -> String:
-    return "[b]Input formats[/b]\n" +
-        "• Plain text: one entry per line. Blank lines and lines starting with '#' are ignored.\n" +
-        "• CSV: the first comma-separated value is treated as the word. Additional columns are ignored.\n" +
-        "• WordListResource: both simple and weighted entries are imported.\n\n" +
-        "[b]Syllabification[/b]\n" +
-        "Entries are split into syllables with a heuristic that keeps the first group as a prefix, optional middle groups as bridge syllables, " +
-        "and the last group as a suffix. Single-syllable words are stored as both prefixes and suffixes so they can stand alone."
+    var lines := [
+        "[b]Input formats[/b]",
+        "• Plain text: one entry per line. Blank lines and lines starting with '#' are ignored.",
+        "• CSV: the first comma-separated value is treated as the word. Additional columns are ignored.",
+        "• WordListResource: both simple and weighted entries are imported.",
+        "",
+        "[b]Syllabification[/b]",
+        "Entries are split into syllables with a heuristic that keeps the first group as a prefix, optional middle groups as bridge syllables,",
+        "and the last group as a suffix. Single-syllable words are stored as both prefixes and suffixes so they can stand alone.",
+    ]
+    return "\n".join(lines)
 
 func _on_load_word_list_pressed() -> void:
     if _file_dialog:

--- a/tests/diagnostics/name_generator_diagnostic.gd
+++ b/tests/diagnostics/name_generator_diagnostic.gd
@@ -128,7 +128,7 @@ func _test_generate_with_override_rng() -> Variant:
         var value := generator.generate(config, rng)
         generator.free()
         return value
-    })
+    )
 
     var second := _with_engine_stub(null, func(_stub_manager = null):
         var generator := _create_generator()
@@ -137,7 +137,7 @@ func _test_generate_with_override_rng() -> Variant:
         var value := generator.generate(config, rng)
         generator.free()
         return value
-    })
+    )
 
     if first is Dictionary:
         return "Override RNG run returned error: %s" % first
@@ -160,14 +160,14 @@ func _test_generate_with_seeded_stream() -> Variant:
         var value := generator.generate(config)
         generator.free()
         return value
-    })
+    )
 
     var second := _with_engine_stub(StubRNGManager.new(), func(_stub_manager = null):
         var generator := _create_generator()
         var value := generator.generate(config)
         generator.free()
         return value
-    })
+    )
 
     if first is Dictionary:
         return "Seeded stream run returned error: %s" % first
@@ -184,7 +184,7 @@ func _test_missing_strategy_error() -> Variant:
         var response := generator.generate({})
         generator.free()
         return response
-    })
+    )
 
     if not (result is Dictionary):
         return "Missing strategy should return an error dictionary."
@@ -206,7 +206,7 @@ func _test_invalid_stream_name_error() -> Variant:
         var response := generator.generate(config)
         generator.free()
         return response
-    })
+    )
 
     if not (result is Dictionary):
         return "Invalid stream name should return an error dictionary."
@@ -228,7 +228,7 @@ func _test_fallback_rng_recording() -> Variant:
         var value := generator.generate(config)
         generator.free()
         return value
-    })
+    )
 
     if result is Dictionary:
         return "Fallback RNG run returned error: %s" % result

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,64 @@
+# GDScript Parse Helper
+
+The `gdscript_parse_helper.py` utility makes it easy to locate and resolve
+GDScript parse errors across this repository.
+
+## Features
+
+- Recursively discovers every `.gd` file under the directories you point it to.
+- Uses [`gdtoolkit`](https://github.com/Scony/godot-gdscript-toolkit) to parse
+  files, matching the behaviour of the Godot editor.
+- Reports the file, line, column, and message for each parse failure.
+- Prints the surrounding source lines so that issues can be fixed rapidly.
+- Supports a machine-readable JSON output mode for integration into other
+  tooling.
+
+## Installation
+
+The tool depends on the [`gdtoolkit`](https://pypi.org/project/gdtoolkit/)
+package.  Install it into your virtual environment (or the current Python
+interpreter) with:
+
+```bash
+pip install gdtoolkit
+```
+
+The repository already ships with `gdtoolkit` in the development environment
+used for this change, but it is listed here for completeness.
+
+## Usage
+
+From the repository root run:
+
+```bash
+python tools/gdscript_parse_helper.py
+```
+
+By default the script scans the current working directory.  You can provide one
+or more paths to limit the search scope:
+
+```bash
+python tools/gdscript_parse_helper.py addons/name_generator
+```
+
+Use `--json` to emit machine-readable output, or `--context-radius` to control
+how many lines of source are displayed around each error:
+
+```bash
+python tools/gdscript_parse_helper.py --context-radius 4 --json
+```
+
+The process exits with status code `0` when no parse errors were found and `1`
+otherwise.  This makes it suitable for CI pipelines and pre-commit hooks.
+
+## Troubleshooting Workflow
+
+1. Run the helper script and note each reported parse error.
+2. Inspect the surrounding context that the tool prints to understand the
+   problem.
+3. Apply the fix in your editor of choice.
+4. Rerun the helper to confirm the error is resolved before committing.
+
+Repeat steps 2–4 until the command finishes without errors.  When combined with
+Godot's own error messages this script provides a fast feedback loop for keeping
+GDScript clean and parseable.

--- a/tools/gdscript_parse_helper.py
+++ b/tools/gdscript_parse_helper.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Utility for inspecting GDScript files for parse errors.
+
+This module walks through a provided directory (or single file) and attempts to
+parse each ``.gd`` file using :mod:`gdtoolkit`.  When a parse error is
+encountered the tool reports the location of the issue, along with a short
+snippet of surrounding lines so it is easier to diagnose the problem.
+
+The exit status is ``0`` when every checked file parses cleanly and ``1`` when
+at least one error is encountered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+try:  # pragma: no cover - import guard is exercised at runtime
+    from gdtoolkit.parser import parser as gdparser
+except ImportError as exc:  # pragma: no cover - handled gracefully in CLI
+    raise SystemExit(
+        "gdtoolkit is required for this script. Install it with 'pip install gdtoolkit'."
+    ) from exc
+
+try:  # pragma: no cover - import guard is exercised at runtime
+    from lark import exceptions as lark_exceptions
+except ImportError as exc:  # pragma: no cover - handled gracefully in CLI
+    raise SystemExit(
+        "The 'lark' dependency is required. It is installed automatically with gdtoolkit."
+    ) from exc
+
+
+@dataclass
+class ParseIssue:
+    """Information about a parse error detected in a GDScript file."""
+
+    path: Path
+    message: str
+    line: int | None
+    column: int | None
+    context: Sequence[str]
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable representation of the issue."""
+
+        return {
+            "path": str(self.path),
+            "message": self.message,
+            "line": self.line,
+            "column": self.column,
+            "context": list(self.context),
+        }
+
+
+def iter_gd_files(paths: Iterable[Path]) -> Iterable[Path]:
+    """Yield all ``.gd`` files contained in ``paths``."""
+
+    for root in paths:
+        root = root.resolve()
+        if root.is_file() and root.suffix == ".gd":
+            yield root
+        elif root.is_dir():
+            for path in sorted(root.rglob("*.gd")):
+                if path.is_file():
+                    yield path
+
+
+def read_context(path: Path, line: int | None, radius: int = 2) -> List[str]:
+    """Return a snippet of text surrounding ``line`` in ``path``.
+
+    When ``line`` is ``None`` the entire file is returned.
+    """
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if line is None:
+        return lines
+
+    start = max(line - 1 - radius, 0)
+    end = min(line - 1 + radius, len(lines) - 1)
+    snippet = []
+    for idx in range(start, end + 1):
+        snippet.append(f"{idx + 1:>5}: {lines[idx]}")
+    return snippet
+
+
+def parse_file(path: Path) -> List[ParseIssue]:
+    """Attempt to parse ``path`` and return any issues that occur."""
+
+    source = path.read_text(encoding="utf-8")
+    try:
+        gdparser.parse(source)
+    except lark_exceptions.LarkError as error:
+        line = getattr(error, "line", None)
+        column = getattr(error, "column", None)
+        message = str(error)
+        context = read_context(path, line)
+        return [ParseIssue(path=path, message=message, line=line, column=column, context=context)]
+    return []
+
+
+def collect_issues(paths: Iterable[Path]) -> List[ParseIssue]:
+    """Gather parse issues for ``paths``."""
+
+    issues: List[ParseIssue] = []
+    for gd_file in iter_gd_files(paths):
+        issues.extend(parse_file(gd_file))
+    return issues
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path.cwd()],
+        help="File or directory paths to inspect. Defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine readable JSON instead of human-readable text.",
+    )
+    parser.add_argument(
+        "--context-radius",
+        type=int,
+        default=2,
+        help="Number of lines of context to show around the offending line (default: %(default)s).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    issues = collect_issues(args.paths)
+
+    if args.json:
+        print(json.dumps([issue.to_dict() for issue in issues], indent=2))
+    else:
+        if not issues:
+            print("No parse issues detected.")
+        else:
+            for index, issue in enumerate(issues, 1):
+                header = f"[{index}] {issue.path}"
+                print(header)
+                if issue.line is not None:
+                    print(f"    line {issue.line}, column {issue.column}")
+                print(f"    {issue.message}")
+                for line in read_context(issue.path, issue.line, args.context_radius):
+                    print(f"    {line}")
+                print()
+            print(f"Total issues found: {len(issues)}")
+
+    return 0 if not issues else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Python utility that uses gdtoolkit to locate GDScript parse errors and provide readable output
- document the helper in tools/README.md with setup, usage, and troubleshooting guidance
- fix parse issues uncovered in the project including ternary usage, stray patch markers, and inline callback closures

## Testing
- python tools/gdscript_parse_helper.py


------
https://chatgpt.com/codex/tasks/task_e_68cb3033ef0c8320a98177cd046da21b