### PR TITLE
Fix autoload RNG manager preload path

### DIFF
--- a/tests/diagnostics/autoload_rng_manager_diagnostic.gd
+++ b/tests/diagnostics/autoload_rng_manager_diagnostic.gd
@@ -1,6 +1,6 @@
 extends RefCounted
 
-const RNGManager := preload("res://autoloads/RNGManager.gd")
+const RNGManager := preload("res://name_generator/RNGManager.gd")
 
 const STREAM_NAMES := ["alpha", "beta", "gamma"]
 const MASTER_SEED := 321987


### PR DESCRIPTION
## Summary
- point the autoload RNG manager diagnostic at the real singleton script under name_generator/

## Testing
- python tools/gdscript_parse_helper.py


------
https://chatgpt.com/codex/tasks/task_e_68cb332c275083208d6fa26d550a8586