### PR TITLE
Fix diagnostics manifest JSON structure

### DIFF
--- a/tests/script_diagnostics_manifest.json
+++ b/tests/script_diagnostics_manifest.json
@@ -12,23 +12,12 @@
     "name_generator": "res://tests/diagnostics/name_generator_diagnostic.gd",
     "name_generator_rng_manager": "res://tests/diagnostics/name_generator_rng_manager_diagnostic.gd",
     "rng_processor": "res://tests/diagnostics/rng_processor_diagnostic.gd",
-    "rng_stream_router": "res://tests/diagnostics/rng_stream_router_diagnostic.gd",
-    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd",
-    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd",
+    "rng_processor_headless": "res://tests/diagnostics/rng_processor_headless_diagnostic.gd",
     "rng_stream_router": "res://tests/diagnostics/rng_stream_router_diagnostic.gd",
     "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd",
     "syllable_set_resource": "res://tests/diagnostics/syllable_set_resource_diagnostic.gd",
     "template_strategy": "res://tests/diagnostics/template_strategy_diagnostic.gd",
     "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd",
-    "rng_processor_headless": "res://tests/diagnostics/rng_processor_headless_diagnostic.gd"
-    "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd"
-    "rng_stream_router": "res://tests/diagnostics/rng_stream_router_diagnostic.gd",
-    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd"
-    "rng_stream_router": "res://tests/diagnostics/rng_stream_router_diagnostic.gd",
-    "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd",
-    "template_strategy": "res://tests/diagnostics/template_strategy_diagnostic.gd",
-    "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd",
     "word_list_resource": "res://tests/diagnostics/word_list_resource_diagnostic.gd"
-
   }
 }


### PR DESCRIPTION
## Summary
- clean up the diagnostics manifest by removing duplicate keys
- add the missing rng_processor_headless entry and restore valid JSON syntax

## Testing
- godot --headless --script res://tests/run_all_tests.gd *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb395b47108320be9ad222174dced9