### PR TITLE
Handle missing resources in name generator tools

### DIFF
--- a/name_generator/tools/README.md
+++ b/name_generator/tools/README.md
@@ -33,4 +33,8 @@ The tool applies the project’s heuristic syllabification algorithm, treating t
 
 After building a set you can review or fine-tune the generated syllables directly in the saved resource.
 
+### Troubleshooting missing files
+
+Both the dock and CLI helpers warn with a `Missing resource` status when the selected asset or the `res://data/` directory cannot be found. The most common fixes are to confirm that the `.tres` file still exists at the path reported in the message or to re-import the `data` folder into the project. Once the asset is back in place, repeat the action and the dock will resume normal operation.
+
 

--- a/name_generator/tools/SyllableSetBuilder.gd
+++ b/name_generator/tools/SyllableSetBuilder.gd
@@ -113,6 +113,10 @@ func _on_load_word_list_pressed() -> void:
         _file_dialog.popup_centered_ratio()
 
 func _on_word_list_selected(path: String) -> void:
+    if not ResourceLoader.exists(path):
+        _set_status("[color=yellow]Missing resource: %s[/color]" % path)
+        return
+
     var resource := load(path)
     if resource == null or not (resource is WORD_LIST_TYPE):
         _set_status("[color=yellow]The selected file is not a WordListResource.[/color]")

--- a/name_generator/tools/dataset_inspector.gd
+++ b/name_generator/tools/dataset_inspector.gd
@@ -9,7 +9,7 @@ func _inspect_datasets() -> void:
     var data_path := "res://data"
     var dir := DirAccess.open(data_path)
     if dir == null:
-        push_error("Data directory not found at %s" % data_path)
+        push_error("Missing resource: data directory not found at %s" % data_path)
         return
 
     dir.list_dir_begin()


### PR DESCRIPTION
## Summary
- add a ResourceLoader.exists guard to keep the Syllable Set Builder responsive when a selected asset is missing
- surface a consistent "Missing resource" error when the dataset inspector cannot reach res://data
- document what the new status message means so artists can restore the missing files

## Testing
- ⚠️ `godot --headless --path . --script res://name_generator/tools/dataset_inspector.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb54b1eec08320aa42de6bc23be388