### PR TITLE
Enhance diagnostic aggregation in test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,18 @@ Additional sub-system references:
 
 ## Running the tests
 
-Execute the automated suite from the repository root to validate gameplay strategies, middleware, and tooling scripts:
+Execute the automated suite from the repository root to validate gameplay strategies, middleware, and tooling scripts. The harness consumes `tests/tests_manifest.json`, running every declared suite followed by the curated diagnostics collection:
 
 ```bash
 godot --headless --script res://tests/run_all_tests.gd
 ```
 
+Each manifest diagnostic now carries a human-readable name and summary, allowing the runner to surface the same per-check context as the suites. At the end of the run, the script prints discrete suite and diagnostic totals plus a combined overall summary and enumerated failure details so engineers can immediately review the concrete issues that need attention.
+
 For targeted debugging, the diagnostics runner executes an individual scenario declared in the diagnostics manifest. Pass the desired ID after a double dash so Godot forwards it to the script unchanged:
 
 ```bash
-godot --headless --script res://tests/run_script_diagnostic.gd -- strategy:hybrid:overlap_window
+godot --headless --script res://tests/run_script_diagnostic.gd --diagnostic-id wordlist_strategy
 ```
 
-The example above isolates the hybrid strategy's overlap window diagnostic without replaying every manifest suite. Refer to `devdocs/tooling.md` for additional QA workflows and manifest management tips.
+The example above isolates the word list strategy diagnostic without replaying every manifest suite. Refer to `devdocs/tooling.md` for additional QA workflows and manifest management tips.

--- a/tests/README
+++ b/tests/README
@@ -1,6 +1,19 @@
 # Test Harness
 
 The project ships standalone headless scenarios alongside the manifest runner.
+
+## Aggregated manifest runner
+
+Execute every suite plus the curated diagnostics from `tests/tests_manifest.json`:
+
+```
+godot --headless --script res://tests/run_all_tests.gd
+```
+
+The script prints individual suite results followed by each manifest diagnostic (including the diagnostic summaries now captured in the manifest). After all executions complete, it reports suite totals, diagnostic totals, and an overall aggregate along with a failure digest drawn from every failing test or diagnostic check.
+
+## Focused scenarios
+
 To execute the RNG processor integration suite directly, run:
 
 ```
@@ -9,3 +22,9 @@ godot --headless --script res://tests/test_rng_processor_headless.gd
 
 Invoke the command from the project root so Godot can resolve the resource
 paths declared in the test script.
+
+For an individual diagnostic registered in the manifest, call the diagnostic runner with the desired ID:
+
+```
+godot --headless --script res://tests/run_script_diagnostic.gd --diagnostic-id wordlist_strategy
+```

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -38,24 +38,27 @@
   "diagnostics": [
     {
       "id": "utils_array_utils",
+      "name": "Array Utilities Diagnostic",
+      "summary": "Verifies deterministic helpers for RNG-aware array operations.",
       "path": "res://tests/diagnostics/utils_array_utils_diagnostic.gd"
-
     },
     {
       "id": "deterministic_array_utils",
+      "name": "Deterministic Array Utilities Diagnostic",
+      "summary": "Checks the deterministic shuffle helpers used by the generator stack.",
       "path": "res://tests/diagnostics/deterministic_array_utils_diagnostic.gd"
-
-
     },
     {
       "id": "wordlist_strategy",
+      "name": "Word List Strategy Diagnostic",
+      "summary": "Validates list-driven name generation strategies and supporting data.",
       "path": "res://tests/diagnostics/wordlist_strategy_diagnostic.gd"
-
     },
     {
       "id": "syllable_chain_strategy",
+      "name": "Syllable Chain Strategy Diagnostic",
+      "summary": "Exercises syllable chain configuration and generation edge cases.",
       "path": "res://tests/diagnostics/syllable_chain_strategy_diagnostic.gd"
-
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add human-readable metadata to diagnostics in `tests/tests_manifest.json`
- extend `tests/run_all_tests.gd` to execute manifest diagnostics, aggregate totals, and summarize failures alongside suites
- update the diagnostic runner to return structured results and document the workflow in the READMEs

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: `godot` binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb54b9aa1c8320a65a38c983c06b91