### PR TITLE
Adapt utilities and diagnostics for Godot 4 runtime

### DIFF
--- a/name_generator/strategies/HybridStrategy.gd
+++ b/name_generator/strategies/HybridStrategy.gd
@@ -179,8 +179,8 @@ func _get_placeholder_regex() -> RegEx:
     return _placeholder_regex
 
 func _generate_via_processor(config: Dictionary, rng: RandomNumberGenerator) -> Variant:
-    if Engine.has_singleton("RNGProcessor"):
-        var processor: Object = Engine.get_singleton("RNGProcessor")
+    if _has_engine_singleton("RNGProcessor"):
+        var processor: Object = _get_engine_singleton("RNGProcessor")
         if processor != null and processor.has_method("generate"):
             return processor.call("generate", config, rng)
     var generator: Object = _resolve_name_generator_singleton()
@@ -213,8 +213,8 @@ func _generate_via_processor(config: Dictionary, rng: RandomNumberGenerator) -> 
 func _resolve_name_generator_singleton() -> Object:
     ## Mirror TemplateStrategy's singleton resolution so hybrid expansions can
     ## safely delegate to the generator without triggering circular preloads.
-    if Engine.has_singleton("NameGenerator"):
-        var singleton: Object = Engine.get_singleton("NameGenerator")
+    if _has_engine_singleton("NameGenerator"):
+        var singleton: Object = _get_engine_singleton("NameGenerator")
         if singleton != null and singleton.has_method("generate"):
             return singleton
     return null
@@ -261,3 +261,9 @@ func describe() -> Dictionary:
         "expected_config": get_config_schema(),
         "notes": notes,
     }
+
+func _has_engine_singleton(name: StringName) -> bool:
+    return Engine.has_singleton(name)
+
+func _get_engine_singleton(name: StringName) -> Object:
+    return Engine.get_singleton(name)

--- a/name_generator/tests/test_hybrid_strategy.gd
+++ b/name_generator/tests/test_hybrid_strategy.gd
@@ -17,6 +17,12 @@ class MissingNameGeneratorHybridStrategy:
     func _resolve_name_generator_singleton() -> Object:
         return null
 
+    func _has_engine_singleton(_name: StringName) -> bool:
+        return false
+
+    func _get_engine_singleton(_name: StringName) -> Object:
+        return null
+
 var _total := 0
 var _passed := 0
 var _failed := 0
@@ -52,23 +58,6 @@ func _run_test(name: String, callable: Callable) -> void:
         "name": name,
         "message": String(message),
     })
-
-func _with_autoloads_disabled(callable: Callable) -> Variant:
-    var original_has := Engine.has_singleton
-    var original_get := Engine.get_singleton
-
-    Engine.has_singleton = func(_name: String) -> bool:
-        return false
-
-    Engine.get_singleton = func(_name: String) -> Variant:
-        return null
-
-    var result = callable.call()
-
-    Engine.has_singleton = original_has
-    Engine.get_singleton = original_get
-
-    return result
 
 func _test_hybrid_structure() -> Variant:
     var strategy := HybridStrategy.new()
@@ -147,9 +136,7 @@ func _test_missing_name_generator_resource() -> Variant:
         ],
     }
 
-    var result := _with_autoloads_disabled(func():
-        return strategy.generate(config, rng)
-    )
+    var result := strategy.generate(config, rng)
 
     if not (result is GeneratorStrategy.GeneratorError):
         return "Expected missing NameGenerator script to return a GeneratorError."

--- a/tests/run_all_tests.gd
+++ b/tests/run_all_tests.gd
@@ -137,22 +137,22 @@ func _execute() -> int:
         else:
             for entry in diagnostics:
                 var diagnostic_info: Dictionary = entry if entry is Dictionary else {}
-                var diagnostic_id: String = diagnostic_info.get("id", "").strip_edges()
-                var diagnostic_name: String = diagnostic_info.get("name", diagnostic_id if diagnostic_id != "" else "Unnamed Diagnostic")
+                var entry_diagnostic_id: String = diagnostic_info.get("id", "").strip_edges()
+                var diagnostic_name: String = diagnostic_info.get("name", entry_diagnostic_id if entry_diagnostic_id != "" else "Unnamed Diagnostic")
                 var diagnostic_summary: String = diagnostic_info.get("summary", "")
 
-                print("Running diagnostic: %s (%s)" % [diagnostic_name, diagnostic_id])
+                print("Running diagnostic: %s (%s)" % [diagnostic_name, entry_diagnostic_id])
                 if diagnostic_summary != "":
                     print("  Summary: %s" % diagnostic_summary)
 
-                if diagnostic_id == "":
+                if entry_diagnostic_id == "":
                     overall_success = false
                     var missing_id_message := "Diagnostic entry is missing an 'id' field."
                     print("  ✗ %s" % missing_id_message)
                     failure_summaries.append("Diagnostic %s :: %s" % [diagnostic_name, missing_id_message])
                     continue
 
-                var diagnostic_result_variant: Variant = runner_script.call("run_diagnostic", diagnostic_id)
+                var diagnostic_result_variant: Variant = runner_script.call("run_diagnostic", entry_diagnostic_id)
                 var diagnostic_result: Dictionary = {}
                 var diagnostic_exit_code := 1
 

--- a/tests/script_diagnostics_manifest.json
+++ b/tests/script_diagnostics_manifest.json
@@ -3,6 +3,7 @@
     "autoload_rng_manager": "res://tests/diagnostics/autoload_rng_manager_diagnostic.gd",
     "dataset_inspector": "res://tests/diagnostics/dataset_inspector_diagnostic.gd",
     "debug_rng": "res://tests/diagnostics/debug_rng_diagnostic.gd",
+    "deterministic_array_utils": "res://tests/diagnostics/deterministic_array_utils_diagnostic.gd",
     "legacy_test_debug_rng": "res://tests/diagnostics/legacy_test_debug_rng_diagnostic.gd",
     "legacy_test_generator_strategy": "res://tests/diagnostics/legacy_test_generator_strategy_diagnostic.gd",
     "legacy_test_hybrid_strategy": "res://tests/diagnostics/legacy_test_hybrid_strategy_diagnostic.gd",
@@ -17,7 +18,9 @@
     "syllable_set_builder": "res://tests/diagnostics/syllable_set_builder_diagnostic.gd",
     "syllable_set_resource": "res://tests/diagnostics/syllable_set_resource_diagnostic.gd",
     "template_strategy": "res://tests/diagnostics/template_strategy_diagnostic.gd",
+    "wordlist_strategy": "res://tests/diagnostics/wordlist_strategy_diagnostic.gd",
     "utils_array_utils": "res://tests/diagnostics/utils_array_utils_diagnostic.gd",
-    "word_list_resource": "res://tests/diagnostics/word_list_resource_diagnostic.gd"
+    "word_list_resource": "res://tests/diagnostics/word_list_resource_diagnostic.gd",
+    "syllable_chain_strategy": "res://tests/diagnostics/syllable_chain_strategy_diagnostic.gd"
   }
 }


### PR DESCRIPTION
## Summary
- wrap HybridStrategy singleton lookups so tests can override Engine access for Godot 4
- refresh the hybrid strategy tests and diagnostics to use the new hooks and telemetry helpers
- extend ArrayUtils with variant-aware assertions plus fallback/assertion tracking for diagnostics
- include missing diagnostics in the manifest and fix the aggregate runner’s ID handling
- modernise the debug RNG diagnostic’s message accumulation to avoid boolean coercion

## Testing
- /workspace/Godot_v4.5-stable_linux.x86_64 --headless --path . --script res://tests/run_all_tests.gd
- /workspace/Godot_v4.5-stable_linux.x86_64 --headless --path . --script res://tests/run_script_diagnostic.gd --diagnostic-id debug_rng

------
https://chatgpt.com/codex/tasks/task_e_68cb58b9bbec8320ade944d5d729b1ff