### PR TITLE
docs: log platform gui verification status

### DIFF
--- a/devdocs/engineering_log.md
+++ b/devdocs/engineering_log.md
@@ -1,0 +1,6 @@
+# Engineering Log
+
+## 2025-09-18
+- **Project configuration** – Confirmed the Godot `project.godot` autoload section still registers the `RNGManager`, `NameGenerator`, and `RNGProcessor` singletons required by the Platform GUI workflows.
+- **Platform GUI validation** – Unable to launch the scene because the `godot4` executable is not present in the current environment; no runtime verification of the Generators, Seeds, or Debug Logs tabs was possible. Downstream tasks will need a workstation with Godot 4.4 installed to complete the handbook walkthrough.
+- **Follow-up actions** – Once Godot 4.4 is available, re-run the Platform GUI workflow to confirm UI behaviour matches `devdocs/platform_gui_handbook.md`, paying particular attention to DebugRNG recording options.


### PR DESCRIPTION
## Summary
- add an engineering log entry that records the autoload verification status and outstanding Platform GUI validation work

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cb67e914f48320aa98f6161497a364