### PR TITLE
Add wordlist panel with metadata-driven previews

### DIFF
--- a/addons/platform_gui/panels/wordlist/WordlistPanel.gd
+++ b/addons/platform_gui/panels/wordlist/WordlistPanel.gd
@@ -1,0 +1,341 @@
+extends VBoxContainer
+
+## Platform GUI panel that exposes WordlistStrategy configuration controls.
+##
+## The node is responsible for rendering the metadata-driven form fields,
+## exposing a catalogue of available WordListResource assets, and brokering
+## preview requests through the RNGProcessor controller. Tool authors can
+## drop the scene into any editor hierarchy, assign the controller and
+## metadata service paths, and immediately offer seeded previews without
+## touching engine singletons from user code.
+
+@export var controller_path: NodePath
+@export var metadata_service_path: NodePath
+
+const WordListResource := preload("res://name_generator/resources/WordListResource.gd")
+
+@onready var _resource_list: ItemList = %ResourceList
+@onready var _weight_toggle: CheckButton = %UseWeights
+@onready var _delimiter_edit: LineEdit = %DelimiterInput
+@onready var _seed_edit: LineEdit = %SeedInput
+@onready var _preview_button: Button = %PreviewButton
+@onready var _preview_label: RichTextLabel = %PreviewOutput
+@onready var _validation_label: Label = %ValidationLabel
+@onready var _metadata_summary: Label = %MetadataSummary
+@onready var _notes_label: Label = %NotesLabel
+
+var _controller_override: Object = null
+var _cached_controller: Object = null
+var _metadata_service_override: Object = null
+var _cached_metadata_service: Object = null
+var _resource_catalog_override: Array = []
+var _resource_cache: Array = []
+
+func _ready() -> void:
+    _preview_button.pressed.connect(_on_preview_button_pressed)
+    %RefreshButton.pressed.connect(_on_refresh_pressed)
+    _refresh_metadata()
+    _refresh_resource_catalog()
+    _update_preview_state(null)
+
+func set_controller_override(controller: Object) -> void:
+    ## Inject a controller for tests or editor tooling. When provided, the
+    ## panel skips all Engine singleton lookups and directs preview requests
+    ## to this override instead.
+    _controller_override = controller
+    _cached_controller = null
+
+func set_metadata_service_override(service: Object) -> void:
+    ## Inject a metadata service for deterministic testing. The override takes
+    ## precedence over the exported NodePath and Engine singleton lookups.
+    _metadata_service_override = service
+    _cached_metadata_service = null
+
+func set_resource_catalog_override(entries: Array) -> void:
+    ## Provide a deterministic catalogue of WordListResource descriptors. This
+    ## is primarily used by automated tests so resource discovery does not walk
+    ## the on-disk project layout.
+    _resource_catalog_override = entries.duplicate(true)
+    _refresh_resource_catalog()
+
+func refresh() -> void:
+    ## Public helper that refreshes both strategy metadata and resource listings.
+    _refresh_metadata()
+    _refresh_resource_catalog()
+
+func get_selected_resource_paths() -> Array:
+    ## Return the resource paths for every selected entry in the resource list.
+    var paths: Array[String] = []
+    for index in _resource_list.get_selected_items():
+        var metadata: Dictionary = _resource_list.get_item_metadata(index)
+        var path: String = String(metadata.get("path", ""))
+        if path != "":
+            paths.append(path)
+    return paths
+
+func build_config_payload() -> Dictionary:
+    ## Construct the middleware configuration dictionary based on the current
+    ## form values. Optional fields are omitted when blank to keep the payload
+    ## faithful to user intent.
+    var config: Dictionary = {
+        "strategy": "wordlist",
+        "wordlist_paths": get_selected_resource_paths(),
+    }
+    var delimiter_text := _delimiter_edit.text
+    if delimiter_text != "":
+        config["delimiter"] = delimiter_text
+    config["use_weights"] = _weight_toggle.button_pressed
+    var seed_value := _seed_edit.text.strip_edges()
+    if seed_value != "":
+        config["seed"] = seed_value
+    return config
+
+func _on_refresh_pressed() -> void:
+    refresh()
+
+func _refresh_metadata() -> void:
+    var service := _get_metadata_service()
+    if service == null:
+        _metadata_summary.text = "Wordlist metadata unavailable."
+        _notes_label.text = ""
+        return
+
+    var required_variant := []
+    if service.has_method("get_required_keys"):
+        required_variant = service.call("get_required_keys", "wordlist")
+    var optional: Dictionary = {}
+    if service.has_method("get_optional_key_types"):
+        optional = service.call("get_optional_key_types", "wordlist")
+    var notes_variant := []
+    if service.has_method("get_default_notes"):
+        notes_variant = service.call("get_default_notes", "wordlist")
+
+    var required_list: Array[String] = []
+    if required_variant is PackedStringArray:
+        required_list.assign(required_variant)
+    elif required_variant is Array:
+        for value in required_variant:
+            required_list.append(String(value))
+
+    var summary := []
+    if not required_list.is_empty():
+        summary.append("Requires: %s" % ", ".join(required_list))
+    if optional is Dictionary and not optional.is_empty():
+        var optional_strings: Array[String] = []
+        for key in optional.keys():
+            var variant_type := int(optional[key])
+            optional_strings.append("%s (%s)" % [key, Variant.get_type_name(variant_type)])
+        optional_strings.sort()
+        summary.append("Optional: %s" % ", ".join(optional_strings))
+    _metadata_summary.text = " | ".join(summary)
+
+    var notes: Array[String] = []
+    if notes_variant is PackedStringArray:
+        notes.assign(notes_variant)
+    elif notes_variant is Array:
+        for value in notes_variant:
+            notes.append(String(value))
+
+    if not notes.is_empty():
+        _notes_label.text = "\n".join(notes)
+    else:
+        _notes_label.text = ""
+
+func _refresh_resource_catalog() -> void:
+    _resource_list.clear()
+    _resource_cache.clear()
+
+    var descriptors: Array = []
+    if not _resource_catalog_override.is_empty():
+        descriptors = _resource_catalog_override.duplicate(true)
+    else:
+        descriptors = _discover_wordlist_resources()
+
+    descriptors.sort_custom(func(a, b):
+        var left_name := String(a.get("display_name", a.get("path", "")))
+        var right_name := String(b.get("display_name", b.get("path", "")))
+        return left_name.nocasecmp_to(right_name) < 0
+    )
+
+    for descriptor in descriptors:
+        if not (descriptor is Dictionary):
+            continue
+        var display_name := String(descriptor.get("display_name", descriptor.get("path", "")))
+        var path := String(descriptor.get("path", ""))
+        if path == "":
+            continue
+        var metadata := {
+            "path": path,
+            "locale": String(descriptor.get("locale", "")),
+            "domain": String(descriptor.get("domain", "")),
+            "has_weights": bool(descriptor.get("has_weights", false)),
+        }
+        var detail_parts: Array[String] = []
+        if metadata["locale"] != "":
+            detail_parts.append(metadata["locale"])
+        if metadata["domain"] != "":
+            detail_parts.append(metadata["domain"])
+        var detail_suffix := detail_parts.join(" · ")
+        var weight_suffix := ""
+        if metadata["has_weights"]:
+            weight_suffix = " (Weighted)"
+        var line := display_name
+        if detail_suffix != "":
+            line += " — %s" % detail_suffix
+        line += weight_suffix
+        var item_index := _resource_list.add_item(line)
+        _resource_list.set_item_metadata(item_index, metadata)
+        _resource_list.set_item_tooltip(item_index, "%s\nPath: %s" % [line, path])
+        _resource_cache.append(metadata)
+
+    if _resource_list.item_count == 0:
+        _resource_list.add_item("No WordListResource assets found.")
+        _resource_list.set_item_disabled(0, true)
+
+func _discover_wordlist_resources() -> Array:
+    ## Recursively scan the data directory for WordListResource assets and
+    ## build descriptive entries for the resource browser. The method favours
+    ## readability over micro-optimisations because the catalogue is refreshed
+    ## only on demand.
+    var results: Array = []
+    var stack: Array[String] = ["res://data"]
+    while not stack.is_empty():
+        var path := stack.pop_back()
+        var dir := DirAccess.open(path)
+        if dir == null:
+            continue
+        dir.list_dir_begin()
+        var entry := dir.get_next()
+        while entry != "":
+            if dir.current_is_dir():
+                if entry.begins_with("."):
+                    entry = dir.get_next()
+                    continue
+                stack.append(path.path_join(entry))
+            else:
+                if not (entry.ends_with(".tres") or entry.ends_with(".res")):
+                    entry = dir.get_next()
+                    continue
+                var resource_path := path.path_join(entry)
+                if not ResourceLoader.exists(resource_path):
+                    entry = dir.get_next()
+                    continue
+                var resource: Resource = ResourceLoader.load(resource_path)
+                if resource == null or not (resource is WordListResource):
+                    entry = dir.get_next()
+                    continue
+                var wordlist: WordListResource = resource
+                results.append({
+                    "path": resource_path,
+                    "display_name": _derive_display_name(resource_path),
+                    "locale": wordlist.locale,
+                    "domain": wordlist.domain,
+                    "has_weights": wordlist.has_weight_data(),
+                })
+            entry = dir.get_next()
+        dir.list_dir_end()
+    return results
+
+func _derive_display_name(path: String) -> String:
+    var segments := path.split("/")
+    if segments.is_empty():
+        return path
+    var filename := segments.back()
+    var trimmed := filename.replace(".tres", "").replace(".res", "")
+    return trimmed.capitalize()
+
+func _on_preview_button_pressed() -> void:
+    var controller := _get_controller()
+    if controller == null:
+        _update_preview_state({
+            "status": "error",
+            "message": "RNGProcessor controller unavailable.",
+        })
+        return
+
+    var config := build_config_payload()
+    if config.get("wordlist_paths", []).is_empty():
+        _update_preview_state({
+            "status": "error",
+            "message": "Select at least one WordListResource to preview output.",
+        })
+        return
+
+    var response: Variant = controller.call("generate", config)
+    if response is Dictionary and response.has("code"):
+        var error_dict: Dictionary = response
+        var message := String(error_dict.get("message", "Generation failed."))
+        _update_preview_state({
+            "status": "error",
+            "message": message,
+            "details": error_dict.get("details", {}),
+        })
+        return
+
+    var output_text := String(response)
+    _update_preview_state({
+        "status": "success",
+        "message": output_text,
+    })
+
+func _update_preview_state(payload: Dictionary) -> void:
+    if payload == null:
+        _preview_label.visible = false
+        _preview_label.text = ""
+        _validation_label.visible = false
+        _validation_label.text = ""
+        return
+
+    var status := String(payload.get("status", ""))
+    var message := String(payload.get("message", ""))
+    if status == "success":
+        _preview_label.visible = true
+        _preview_label.text = "[b]Preview:[/b]\n%s" % message
+        _validation_label.visible = false
+        _validation_label.text = ""
+    else:
+        _preview_label.visible = false
+        _preview_label.text = ""
+        _validation_label.visible = true
+        _validation_label.text = message
+
+func _get_controller() -> Object:
+    if _controller_override != null and _is_object_valid(_controller_override):
+        return _controller_override
+    if _cached_controller != null and _is_object_valid(_cached_controller):
+        return _cached_controller
+    if controller_path != NodePath("") and has_node(controller_path):
+        var node := get_node(controller_path)
+        if node != null:
+            _cached_controller = node
+            return _cached_controller
+    if Engine.has_singleton("RNGProcessorController"):
+        var singleton := Engine.get_singleton("RNGProcessorController")
+        if _is_object_valid(singleton):
+            _cached_controller = singleton
+            return _cached_controller
+    return null
+
+func _get_metadata_service() -> Object:
+    if _metadata_service_override != null and _is_object_valid(_metadata_service_override):
+        return _metadata_service_override
+    if _cached_metadata_service != null and _is_object_valid(_cached_metadata_service):
+        return _cached_metadata_service
+    if metadata_service_path != NodePath("") and has_node(metadata_service_path):
+        var node := get_node(metadata_service_path)
+        if node != null:
+            _cached_metadata_service = node
+            return _cached_metadata_service
+    if Engine.has_singleton("StrategyMetadataService"):
+        var singleton := Engine.get_singleton("StrategyMetadataService")
+        if _is_object_valid(singleton):
+            _cached_metadata_service = singleton
+            return _cached_metadata_service
+    return null
+
+func _is_object_valid(candidate: Object) -> bool:
+    if candidate == null:
+        return false
+    if candidate is Node:
+        return is_instance_valid(candidate)
+    return true

--- a/addons/platform_gui/panels/wordlist/WordlistPanel.tscn
+++ b/addons/platform_gui/panels/wordlist/WordlistPanel.tscn
@@ -1,0 +1,90 @@
+[gd_scene load_steps=2 format=3 uid="uid://wordlistpanel"]
+
+[ext_resource type="Script" path="res://addons/platform_gui/panels/wordlist/WordlistPanel.gd" id="1_x0gui"]
+
+[node name="WordlistPanel" type="VBoxContainer"]
+custom_minimum_size = Vector2(480, 0)
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+theme_override_constants/separation = 12
+script = ExtResource("1_x0gui")
+
+[node name="Header" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 8
+
+[node name="Title" type="Label" parent="Header"]
+theme_override_font_sizes/font_size = 18
+text = "Word List Strategy"
+
+[node name="HeaderSpacer" type="Control" parent="Header"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+[node name="RefreshButton" type="Button" parent="Header"]
+flat = true
+text = "Refresh"
+tooltip_text = "Reload strategy metadata and the resource catalogue."
+
+[node name="MetadataSummary" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = ""
+
+[node name="NotesLabel" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = ""
+
+[node name="ResourceSection" type="VBoxContainer" parent="."]
+theme_override_constants/separation = 4
+
+[node name="ResourceLabel" type="Label" parent="ResourceSection"]
+text = "Available word lists"
+
+[node name="ResourceList" type="ItemList" parent="ResourceSection"]
+allow_reselect = true
+allow_rmb_select = true
+custom_minimum_size = Vector2(0, 220)
+select_mode = ItemList.SELECT_MULTI
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+[node name="OptionsSection" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 12
+
+[node name="UseWeights" type="CheckButton" parent="OptionsSection"]
+text = "Use weights when available"
+
+[node name="DelimiterContainer" type="HBoxContainer" parent="OptionsSection"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_FILL
+
+[node name="DelimiterLabel" type="Label" parent="OptionsSection/DelimiterContainer"]
+text = "Delimiter"
+
+[node name="DelimiterInput" type="LineEdit" parent="OptionsSection/DelimiterContainer"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+text = " "
+tooltip_text = "Leave blank to use a single space between selections."
+
+[node name="PreviewRow" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 12
+
+[node name="SeedLabel" type="Label" parent="PreviewRow"]
+text = "Seed"
+
+[node name="SeedInput" type="LineEdit" parent="PreviewRow"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+placeholder_text = "Optional seed label"
+
+[node name="PreviewButton" type="Button" parent="PreviewRow"]
+text = "Preview"
+
+[node name="ValidationLabel" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+self_modulate = Color(0.870588, 0.196078, 0.203922, 1)
+visible = false
+
+[node name="PreviewOutput" type="RichTextLabel" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+bbcode_enabled = true
+fit_content = true
+scroll_active = false
+visible = false

--- a/devdocs/platform_gui_handbook.md
+++ b/devdocs/platform_gui_handbook.md
@@ -23,6 +23,17 @@ Follow these steps whenever you need to work inside the Platform GUI:
 4. Press **Generate**. The GUI calls `RNGProcessor.generate(config)` behind the scenes. While the middleware processes the request, the interface shows a status spinner driven by the `generation_started` signal.
 5. Review the result. Successful runs display the returned payload alongside the resolved seed and RNG stream name reported by `generation_completed`. If the middleware emits `generation_failed`, the GUI surfaces the human-readable error message plus suggested fixes.
 
+### Configuring word list strategies
+
+1. Choose **Word List** from the strategy dropdown to load the dedicated panel.
+2. Review the metadata banner above the form: the required and optional keys are sourced from the cached middleware schema so you know which fields must be filled before generating.
+3. Use the resource browser to select one or more `WordListResource` assets. Each entry shows locale, domain, and whether weighting data is available so you can mix compatible lists at a glance.
+4. Toggle **Use weights when available** if you want the middleware to respect weighted entries for every selected resource.
+5. Adjust the delimiter field to control how sampled values are joined. Leaving the input blank defaults to a single space.
+6. Provide an optional seed label in the preview row. The panel passes it straight to `RNGProcessor.generate(...)` so repeat previews with the same seed remain deterministic.
+7. Press **Preview** to request a seeded sample from the middleware. Successful runs render the preview inline, while validation errors appear in red beneath the controls so you can correct the form without leaving the panel.
+8. Click **Refresh** if you add new word lists to the project mid-session. The button reloads both the metadata schema and the resource catalogue.
+
 ### Reviewing DebugRNG logs
 
 1. Switch to the **Debug Logs** tab. When DebugRNG is active, the middleware writes to `user://debug_rng_report.txt` (or a custom path you configured earlier).

--- a/tests/gui/test_wordlist_panel.gd
+++ b/tests/gui/test_wordlist_panel.gd
@@ -1,0 +1,241 @@
+extends RefCounted
+
+const PANEL_SCENE := preload("res://addons/platform_gui/panels/wordlist/WordlistPanel.tscn")
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _reset()
+
+    _run_test("loads_metadata_summary", func(): _test_loads_metadata_summary())
+    _run_test("renders_resource_catalogue", func(): _test_renders_resource_catalogue())
+    _run_test("handles_preview_results", func(): _test_handles_preview_results())
+    _run_test("surfaces_validation_errors", func(): _test_surfaces_validation_errors())
+
+    return {
+        "suite": "Platform GUI Wordlist Panel",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+        return
+    _failed += 1
+    _failures.append({
+        "name": name,
+        "message": String(message),
+    })
+
+func _test_loads_metadata_summary() -> Variant:
+    var metadata := MetadataStub.new()
+    metadata.required_keys = PackedStringArray(["wordlist_paths"])
+    metadata.optional_key_types = {
+        "delimiter": TYPE_STRING,
+        "use_weights": TYPE_BOOL,
+    }
+    metadata.notes = PackedStringArray(["Wordlist note guidance."])
+
+    var context := _make_panel(metadata)
+    var panel: VBoxContainer = context["panel"]
+    panel._ready()
+
+    var summary_text := panel.get_node("MetadataSummary").text
+    if summary_text.find("Requires: wordlist_paths") == -1:
+        return "Metadata summary should list required keys from the cache."
+    if summary_text.find("delimiter") == -1 or summary_text.find("weights") == -1:
+        return "Metadata summary should describe optional key expectations."
+
+    var notes_text := panel.get_node("NotesLabel").text
+    if notes_text.find("Wordlist note guidance.") == -1:
+        return "Metadata notes should surface narrative guidance for artists."
+
+    panel.free()
+    metadata.free()
+    (context["controller"] as ControllerStub).free()
+    return null
+
+func _test_renders_resource_catalogue() -> Variant:
+    var context := _make_panel(MetadataStub.new())
+    var panel: VBoxContainer = context["panel"]
+    panel._ready()
+
+    var descriptors := [
+        {
+            "path": "res://data/example_alpha.tres",
+            "display_name": "Alpha",
+            "locale": "en",
+            "domain": "people",
+            "has_weights": true,
+        },
+        {
+            "path": "res://data/example_beta.tres",
+            "display_name": "Beta",
+            "locale": "",
+            "domain": "",
+            "has_weights": false,
+        },
+    ]
+    panel.set_resource_catalog_override(descriptors)
+
+    var resource_list: ItemList = panel.get_node("ResourceSection/ResourceList")
+    if resource_list.item_count != 2:
+        return "Resource browser should list every provided WordListResource."
+
+    var first_text := resource_list.get_item_text(0)
+    if first_text.find("Alpha") == -1 or first_text.find("Weighted") == -1:
+        return "Resource entries should surface weighting state inline."
+
+    var first_metadata: Dictionary = resource_list.get_item_metadata(0)
+    if first_metadata.get("path", "") != "res://data/example_alpha.tres":
+        return "Resource metadata should preserve the original resource path."
+    if first_metadata.get("locale", "") != "en" or first_metadata.get("domain", "") != "people":
+        return "Resource metadata should include locale and domain context."
+
+    panel.free()
+    (context["metadata"] as MetadataStub).free()
+    (context["controller"] as ControllerStub).free()
+    return null
+
+func _test_handles_preview_results() -> Variant:
+    var metadata := MetadataStub.new()
+    metadata.required_keys = PackedStringArray(["wordlist_paths"])
+
+    var controller := ControllerStub.new()
+    controller.response = "Arcane sigil"
+
+    var panel := PANEL_SCENE.instantiate() as VBoxContainer
+    panel.set_metadata_service_override(metadata)
+    panel.set_controller_override(controller)
+    panel._ready()
+
+    panel.set_resource_catalog_override([
+        {
+            "path": "res://data/example_gamma.tres",
+            "display_name": "Gamma",
+            "locale": "en",
+            "domain": "rituals",
+            "has_weights": false,
+        },
+    ])
+
+    var resource_list: ItemList = panel.get_node("ResourceSection/ResourceList")
+    resource_list.select(0)
+    var weight_toggle: CheckButton = panel.get_node("OptionsSection/UseWeights")
+    weight_toggle.button_pressed = true
+    var delimiter_input: LineEdit = panel.get_node("OptionsSection/DelimiterContainer/DelimiterInput")
+    delimiter_input.text = "-"
+    var seed_input: LineEdit = panel.get_node("PreviewRow/SeedInput")
+    seed_input.text = "demo_seed"
+
+    panel._on_preview_button_pressed()
+
+    if controller.last_config.get("seed", "") != "demo_seed":
+        return "Preview should include the user-specified seed value."
+    if controller.last_config.get("use_weights", false) != true:
+        return "Preview should respect the weight toggle state."
+    if controller.last_config.get("delimiter", "") != "-":
+        return "Preview should pass the delimiter through to the middleware."
+    var paths: Array = controller.last_config.get("wordlist_paths", [])
+    if paths.size() != 1 or paths[0] != "res://data/example_gamma.tres":
+        return "Preview should only send the selected word list resources."
+
+    var preview_label: RichTextLabel = panel.get_node("PreviewOutput")
+    if not preview_label.visible or preview_label.text.find("Arcane sigil") == -1:
+        return "Successful previews should surface the returned sample output."
+
+    panel.free()
+    metadata.free()
+    controller.free()
+    return null
+
+func _test_surfaces_validation_errors() -> Variant:
+    var metadata := MetadataStub.new()
+    metadata.required_keys = PackedStringArray(["wordlist_paths"])
+
+    var controller := ControllerStub.new()
+    controller.response = {
+        "code": "wordlists_missing",
+        "message": "No word lists selected.",
+    }
+
+    var panel := PANEL_SCENE.instantiate() as VBoxContainer
+    panel.set_metadata_service_override(metadata)
+    panel.set_controller_override(controller)
+    panel._ready()
+    panel.set_resource_catalog_override([
+        {
+            "path": "res://data/example_delta.tres",
+            "display_name": "Delta",
+            "locale": "en",
+            "domain": "alchemy",
+            "has_weights": false,
+        },
+    ])
+
+    var resource_list: ItemList = panel.get_node("ResourceSection/ResourceList")
+    resource_list.select(0)
+
+    panel._on_preview_button_pressed()
+
+    var validation_label: Label = panel.get_node("ValidationLabel")
+    if not validation_label.visible:
+        return "Validation label should appear when the middleware returns an error."
+    if validation_label.text.find("No word lists selected.") == -1:
+        return "Validation feedback should surface the middleware error message."
+
+    panel.free()
+    metadata.free()
+    controller.free()
+    return null
+
+func _make_panel(metadata: MetadataStub) -> Dictionary:
+    var controller := ControllerStub.new()
+    var panel := PANEL_SCENE.instantiate() as VBoxContainer
+    panel.set_metadata_service_override(metadata)
+    panel.set_controller_override(controller)
+    return {
+        "panel": panel,
+        "metadata": metadata,
+        "controller": controller,
+    }
+
+func _reset() -> void:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+class MetadataStub:
+    extends Node
+
+    var required_keys: PackedStringArray = PackedStringArray()
+    var optional_key_types: Dictionary = {}
+    var notes: PackedStringArray = PackedStringArray()
+
+    func get_required_keys(_strategy_id: String) -> PackedStringArray:
+        return required_keys.duplicate()
+
+    func get_optional_key_types(_strategy_id: String) -> Dictionary:
+        return optional_key_types.duplicate(true)
+
+    func get_default_notes(_strategy_id: String) -> PackedStringArray:
+        return notes.duplicate()
+
+class ControllerStub:
+    extends Node
+
+    var response: Variant = ""
+    var last_config: Dictionary = {}
+
+    func generate(config: Dictionary) -> Variant:
+        last_config = config.duplicate(true)
+        return response

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -29,6 +29,10 @@
       "path": "res://tests/gui/test_strategy_metadata_service.gd"
     },
     {
+      "name": "Platform GUI Wordlist Panel Suite",
+      "path": "res://tests/gui/test_wordlist_panel.gd"
+    },
+    {
       "name": "Name Generator Diagnostic",
       "path": "res://tests/diagnostics/name_generator_diagnostic.gd",
       "id": "name_generator"


### PR DESCRIPTION
## Summary
- add a reusable Word List strategy panel that reads cached metadata, lists resources, and surfaces seeded previews
- cover the panel with deterministic GUI tests and register the suite in the manifest
- expand the artist handbook with step-by-step guidance for the new workflow

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: `godot` executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6ec827b483209c1a78b854c56d23