### PR TITLE
Add syllable chain panel to platform GUI

### DIFF
--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
@@ -1,0 +1,534 @@
+extends VBoxContainer
+
+## Platform GUI panel that configures the SyllableChainStrategy.
+##
+## The widget mirrors the structure of the word list panel: it discovers
+## available SyllableSetResource assets, exposes metadata provided by the
+## middleware, and offers deterministic previews through the RNGProcessor
+## controller. Artists can drop the scene into existing editor hierarchies
+## and wire up controller/metadata service paths without touching engine
+## singletons during authoring.
+
+@export var controller_path: NodePath
+@export var metadata_service_path: NodePath
+
+const SyllableSetResource := preload("res://name_generator/resources/SyllableSetResource.gd")
+
+@onready var _resource_list: ItemList = %ResourceList
+@onready var _resource_summary_label: Label = %ResourceSummary
+@onready var _require_middle_toggle: CheckButton = %RequireMiddle
+@onready var _middle_min_spin: SpinBox = %MiddleMinSpin
+@onready var _middle_max_spin: SpinBox = %MiddleMaxSpin
+@onready var _min_length_spin: SpinBox = %MinLengthSpin
+@onready var _regex_preset_container: VBoxContainer = %RegexPresetContainer
+@onready var _seed_edit: LineEdit = %SeedInput
+@onready var _preview_button: Button = %PreviewButton
+@onready var _preview_label: RichTextLabel = %PreviewOutput
+@onready var _validation_label: Label = %ValidationLabel
+@onready var _metadata_summary: Label = %MetadataSummary
+@onready var _notes_label: Label = %NotesLabel
+
+var _controller_override: Object = null
+var _cached_controller: Object = null
+var _metadata_service_override: Object = null
+var _cached_metadata_service: Object = null
+var _resource_catalog_override: Array = []
+var _resource_cache: Array = []
+var _regex_presets: Dictionary = {}
+var _control_default_modulates: Dictionary = {}
+
+const _ERROR_TINT := Color(1.0, 0.85, 0.85, 1.0)
+
+const REGEX_PRESETS := [
+    {
+        "id": "collapse_triplicate_letters",
+        "label": "Collapse triple letters",
+        "description": "Replace three or more repeated letters with a doublet.",
+        "rules": [
+            {"pattern": "([A-Za-z])\\1{2,}", "replacement": "\\1\\1"},
+        ],
+    },
+    {
+        "id": "trim_apostrophes",
+        "label": "Trim stray apostrophes",
+        "description": "Remove leading/trailing apostrophes left behind by joins.",
+        "rules": [
+            {"pattern": "^'+", "replacement": ""},
+            {"pattern": "'+$", "replacement": ""},
+        ],
+    },
+    {
+        "id": "normalise_separators",
+        "label": "Normalise separators",
+        "description": "Swap multiple separators for a single hyphen and strip spaces.",
+        "rules": [
+            {"pattern": "[ _-]{2,}", "replacement": "-"},
+            {"pattern": "\\s+-", "replacement": "-"},
+            {"pattern": "-\\s+", "replacement": "-"},
+        ],
+    },
+]
+
+func _ready() -> void:
+    _preview_button.pressed.connect(_on_preview_button_pressed)
+    %RefreshButton.pressed.connect(_on_refresh_pressed)
+    _resource_list.item_selected.connect(_on_resource_selected)
+    _require_middle_toggle.toggled.connect(_on_require_middle_toggled)
+    _build_regex_preset_controls()
+    _track_default_modulate(_resource_list)
+    _track_default_modulate(_middle_min_spin)
+    _track_default_modulate(_middle_max_spin)
+    _refresh_metadata()
+    _refresh_resource_catalog()
+    _update_preview_state(null)
+
+func set_controller_override(controller: Object) -> void:
+    _controller_override = controller
+    _cached_controller = null
+
+func set_metadata_service_override(service: Object) -> void:
+    _metadata_service_override = service
+    _cached_metadata_service = null
+
+func set_resource_catalog_override(entries: Array) -> void:
+    _resource_catalog_override = entries.duplicate(true)
+    _refresh_resource_catalog()
+
+func refresh() -> void:
+    _refresh_metadata()
+    _refresh_resource_catalog()
+
+func build_config_payload() -> Dictionary:
+    var config: Dictionary = {
+        "strategy": "syllable",
+    }
+    var path := _get_selected_resource_path()
+    if path != "":
+        config["syllable_set_path"] = path
+    config["require_middle"] = _require_middle_toggle.button_pressed
+
+    var min_middle := int(_middle_min_spin.value)
+    var max_middle := int(_middle_max_spin.value)
+    config["middle_syllables"] = {"min": min_middle, "max": max_middle}
+
+    var min_length := int(_min_length_spin.value)
+    if min_length > 0:
+        config["min_length"] = min_length
+
+    var seed_value := _seed_edit.text.strip_edges()
+    if seed_value != "":
+        config["seed"] = seed_value
+
+    var rules := _collect_selected_regex_rules()
+    if not rules.is_empty():
+        config["post_processing_rules"] = rules
+
+    return config
+
+func get_selected_resource_path() -> String:
+    return _get_selected_resource_path()
+
+func _on_refresh_pressed() -> void:
+    refresh()
+
+func _on_resource_selected(_index: int) -> void:
+    _update_selected_resource_summary()
+
+func _on_require_middle_toggled(pressed: bool) -> void:
+    if pressed and _middle_min_spin.value < 1:
+        _middle_min_spin.value = 1
+    if pressed and _middle_max_spin.value < 1:
+        _middle_max_spin.value = 1
+
+func _build_regex_preset_controls() -> void:
+    for child in _regex_preset_container.get_children():
+        child.queue_free()
+    _regex_presets.clear()
+
+    for preset in REGEX_PRESETS:
+        if not (preset is Dictionary):
+            continue
+        var identifier := String(preset.get("id", ""))
+        if identifier == "":
+            continue
+        var button := CheckBox.new()
+        button.text = String(preset.get("label", identifier.capitalize()))
+        button.tooltip_text = String(preset.get("description", ""))
+        _regex_preset_container.add_child(button)
+        _regex_presets[identifier] = {
+            "definition": preset,
+            "control": button,
+        }
+
+func _refresh_metadata() -> void:
+    var service := _get_metadata_service()
+    if service == null:
+        _metadata_summary.text = "Syllable strategy metadata unavailable."
+        _notes_label.text = ""
+        return
+
+    var required_variant := []
+    if service.has_method("get_required_keys"):
+        required_variant = service.call("get_required_keys", "syllable")
+    var optional: Dictionary = {}
+    if service.has_method("get_optional_key_types"):
+        optional = service.call("get_optional_key_types", "syllable")
+    var notes_variant := []
+    if service.has_method("get_default_notes"):
+        notes_variant = service.call("get_default_notes", "syllable")
+
+    var required_list: Array[String] = []
+    if required_variant is PackedStringArray:
+        required_list.assign(required_variant)
+    elif required_variant is Array:
+        for value in required_variant:
+            required_list.append(String(value))
+
+    var summary := []
+    if not required_list.is_empty():
+        summary.append("Requires: %s" % ", ".join(required_list))
+    if optional is Dictionary and not optional.is_empty():
+        var optional_strings: Array[String] = []
+        for key in optional.keys():
+            var variant_type := int(optional[key])
+            optional_strings.append("%s (%s)" % [key, Variant.get_type_name(variant_type)])
+        optional_strings.sort()
+        summary.append("Optional: %s" % ", ".join(optional_strings))
+    _metadata_summary.text = " | ".join(summary)
+
+    var notes: Array[String] = []
+    if notes_variant is PackedStringArray:
+        notes.assign(notes_variant)
+    elif notes_variant is Array:
+        for value in notes_variant:
+            notes.append(String(value))
+
+    if not notes.is_empty():
+        _notes_label.text = "\n".join(notes)
+    else:
+        _notes_label.text = ""
+
+func _refresh_resource_catalog() -> void:
+    _resource_list.clear()
+    _resource_cache.clear()
+    _resource_summary_label.text = "Select a syllable set to review its details."
+
+    var descriptors: Array = []
+    if not _resource_catalog_override.is_empty():
+        descriptors = _resource_catalog_override.duplicate(true)
+    else:
+        descriptors = _discover_syllable_resources()
+
+    descriptors.sort_custom(func(a, b):
+        var left := String(a.get("display_name", a.get("path", "")))
+        var right := String(b.get("display_name", b.get("path", "")))
+        return left.nocasecmp_to(right) < 0
+    )
+
+    for descriptor in descriptors:
+        if not (descriptor is Dictionary):
+            continue
+        var display_name := String(descriptor.get("display_name", descriptor.get("path", "")))
+        var path := String(descriptor.get("path", ""))
+        if path == "":
+            continue
+
+        var metadata := {
+            "path": path,
+            "locale": String(descriptor.get("locale", "")),
+            "domain": String(descriptor.get("domain", "")),
+            "prefix_count": int(descriptor.get("prefix_count", 0)),
+            "middle_count": int(descriptor.get("middle_count", 0)),
+            "suffix_count": int(descriptor.get("suffix_count", 0)),
+            "allow_empty_middle": bool(descriptor.get("allow_empty_middle", true)),
+        }
+
+        var detail_parts: Array[String] = []
+        if metadata["locale"] != "":
+            detail_parts.append(metadata["locale"])
+        if metadata["domain"] != "":
+            detail_parts.append(metadata["domain"])
+        var detail_suffix := detail_parts.join(" · ")
+        var counts := "P:%d | M:%d | S:%d" % [metadata["prefix_count"], metadata["middle_count"], metadata["suffix_count"]]
+
+        var line := display_name
+        if detail_suffix != "":
+            line += " — %s" % detail_suffix
+        line += " (%s)" % counts
+
+        var item_index := _resource_list.add_item(line)
+        _resource_list.set_item_metadata(item_index, metadata)
+        var tooltip_lines := [
+            "Path: %s" % path,
+            "Locale: %s" % (metadata["locale"] if metadata["locale"] != "" else "—"),
+            "Domain: %s" % (metadata["domain"] if metadata["domain"] != "" else "—"),
+            "Prefixes: %d" % metadata["prefix_count"],
+            "Middles: %d" % metadata["middle_count"],
+            "Suffixes: %d" % metadata["suffix_count"],
+        ]
+        if not metadata["allow_empty_middle"] and metadata["middle_count"] > 0:
+            tooltip_lines.append("Requires at least one middle syllable.")
+        _resource_list.set_item_tooltip(item_index, "\n".join(tooltip_lines))
+        _resource_cache.append(metadata)
+
+    if _resource_list.item_count == 0:
+        _resource_list.add_item("No SyllableSetResource assets found.")
+        _resource_list.set_item_disabled(0, true)
+
+func _discover_syllable_resources() -> Array:
+    var results: Array = []
+    var stack: Array[String] = ["res://data"]
+    while not stack.is_empty():
+        var path := stack.pop_back()
+        var dir := DirAccess.open(path)
+        if dir == null:
+            continue
+        dir.list_dir_begin()
+        var entry := dir.get_next()
+        while entry != "":
+            if dir.current_is_dir():
+                if entry.begins_with("."):
+                    entry = dir.get_next()
+                    continue
+                stack.append(path.path_join(entry))
+            else:
+                if not (entry.ends_with(".tres") or entry.ends_with(".res")):
+                    entry = dir.get_next()
+                    continue
+                var resource_path := path.path_join(entry)
+                if not ResourceLoader.exists(resource_path):
+                    entry = dir.get_next()
+                    continue
+                var resource: Resource = ResourceLoader.load(resource_path)
+                if resource == null or not (resource is SyllableSetResource):
+                    entry = dir.get_next()
+                    continue
+                var syllable_set: SyllableSetResource = resource
+                results.append({
+                    "path": resource_path,
+                    "display_name": _derive_display_name(resource_path),
+                    "locale": syllable_set.locale,
+                    "domain": syllable_set.domain,
+                    "prefix_count": syllable_set.prefixes.size(),
+                    "middle_count": syllable_set.middles.size(),
+                    "suffix_count": syllable_set.suffixes.size(),
+                    "allow_empty_middle": syllable_set.allow_empty_middle,
+                })
+            entry = dir.get_next()
+        dir.list_dir_end()
+    return results
+
+func _derive_display_name(path: String) -> String:
+    var segments := path.split("/")
+    if segments.is_empty():
+        return path
+    var filename := segments.back()
+    var trimmed := filename.replace(".tres", "").replace(".res", "")
+    return trimmed.capitalize()
+
+func _on_preview_button_pressed() -> void:
+    var path := _get_selected_resource_path()
+    if path == "":
+        _update_preview_state({
+            "status": "error",
+            "message": "Select a syllable set before requesting a preview.",
+            "highlight_resource": true,
+        })
+        return
+
+    var controller := _get_controller()
+    if controller == null:
+        _update_preview_state({
+            "status": "error",
+            "message": "RNGProcessor controller unavailable.",
+        })
+        return
+
+    var config := build_config_payload()
+    if int(config["middle_syllables"].get("min", 0)) > int(config["middle_syllables"].get("max", 0)):
+        _update_preview_state({
+            "status": "error",
+            "message": "Middle syllable minimum must be less than or equal to the maximum.",
+            "highlight_range": true,
+        })
+        return
+
+    var response: Variant = controller.call("generate", config)
+    if response is Dictionary and response.has("code"):
+        var error_dict: Dictionary = response
+        var message := String(error_dict.get("message", "Generation failed."))
+        var hint := _lookup_error_hint(String(error_dict.get("code", "")))
+        if hint != "":
+            message += "\n%s" % hint
+        _update_preview_state({
+            "status": "error",
+            "message": message,
+            "details": error_dict.get("details", {}),
+            "highlight_resource": String(error_dict.get("code", "")) == "missing_resource",
+            "highlight_range": _should_highlight_range(error_dict.get("code", "")),
+        })
+        return
+
+    var output_text := String(response)
+    _update_preview_state({
+        "status": "success",
+        "message": output_text,
+    })
+
+func _lookup_error_hint(code: String) -> String:
+    if code == "":
+        return ""
+    var service := _get_metadata_service()
+    if service != null and service.has_method("get_generator_error_hint"):
+        return String(service.call("get_generator_error_hint", "syllable", code))
+    return ""
+
+func _should_highlight_range(code: String) -> bool:
+    match code:
+        "invalid_middle_range":
+            return true
+        "middle_syllables_not_available":
+            return true
+        "missing_required_middles":
+            return true
+        _:
+            return false
+
+func _update_preview_state(payload: Dictionary) -> void:
+    _preview_label.visible = false
+    _preview_label.text = ""
+    _validation_label.visible = false
+    _validation_label.text = ""
+    _set_control_highlight(_resource_list, false)
+    _set_control_highlight(_middle_min_spin, false)
+    _set_control_highlight(_middle_max_spin, false)
+
+    if payload == null:
+        return
+
+    var status := String(payload.get("status", ""))
+    var message := String(payload.get("message", ""))
+    if status == "success":
+        _preview_label.visible = true
+        _preview_label.text = "[b]Preview:[/b]\n%s" % message
+    else:
+        _validation_label.visible = true
+        _validation_label.text = message
+        if bool(payload.get("highlight_resource", false)):
+            _set_control_highlight(_resource_list, true)
+        if bool(payload.get("highlight_range", false)):
+            _set_control_highlight(_middle_min_spin, true)
+            _set_control_highlight(_middle_max_spin, true)
+
+func _update_selected_resource_summary() -> void:
+    var metadata := _get_selected_resource_metadata()
+    if metadata.is_empty():
+        _resource_summary_label.text = "Select a syllable set to review its details."
+        return
+
+    var lines := [
+        "Path: %s" % metadata["path"],
+        "Locale: %s" % (metadata["locale"] if metadata["locale"] != "" else "—"),
+        "Domain: %s" % (metadata["domain"] if metadata["domain"] != "" else "—"),
+        "Prefixes: %d" % metadata["prefix_count"],
+        "Middles: %d" % metadata["middle_count"],
+        "Suffixes: %d" % metadata["suffix_count"],
+    ]
+    if not metadata["allow_empty_middle"] and metadata["middle_count"] > 0:
+        lines.append("Requires at least one middle syllable.")
+    _resource_summary_label.text = "\n".join(lines)
+
+    var available_middles := int(metadata["middle_count"])
+    if available_middles > _middle_max_spin.max_value:
+        _middle_max_spin.max_value = available_middles
+    _middle_min_spin.max_value = _middle_max_spin.max_value
+
+    if _middle_min_spin.value > _middle_min_spin.max_value:
+        _middle_min_spin.value = _middle_min_spin.max_value
+    if _middle_max_spin.value < _middle_min_spin.value:
+        _middle_max_spin.value = _middle_min_spin.value
+
+func _collect_selected_regex_rules() -> Array:
+    var rules: Array = []
+    for identifier in _regex_presets.keys():
+        var entry: Dictionary = _regex_presets[identifier]
+        var control: CheckBox = entry.get("control", null)
+        if control == null or not control.button_pressed:
+            continue
+        var definition: Dictionary = entry.get("definition", {})
+        var preset_rules: Variant = definition.get("rules", [])
+        if preset_rules is Array:
+            for rule in preset_rules:
+                if rule is Dictionary:
+                    rules.append(rule.duplicate(true))
+    return rules
+
+func _get_selected_resource_path() -> String:
+    var metadata := _get_selected_resource_metadata()
+    if metadata.is_empty():
+        return ""
+    return String(metadata.get("path", ""))
+
+func _get_selected_resource_metadata() -> Dictionary:
+    var indices := _resource_list.get_selected_items()
+    if indices.is_empty():
+        return {}
+    var metadata: Dictionary = _resource_list.get_item_metadata(indices[0])
+    if metadata == null:
+        return {}
+    return metadata.duplicate(true)
+
+func _track_default_modulate(control: CanvasItem) -> void:
+    if control == null:
+        return
+    _control_default_modulates[control] = control.modulate
+
+func _set_control_highlight(control: CanvasItem, enabled: bool) -> void:
+    if control == null:
+        return
+    if enabled:
+        control.modulate = _ERROR_TINT
+    else:
+        var original := _control_default_modulates.get(control, Color(1, 1, 1, 1))
+        control.modulate = original
+
+func _get_controller() -> Object:
+    if _controller_override != null and _is_object_valid(_controller_override):
+        return _controller_override
+    if _cached_controller != null and _is_object_valid(_cached_controller):
+        return _cached_controller
+    if controller_path != NodePath("") and has_node(controller_path):
+        var node := get_node(controller_path)
+        if node != null:
+            _cached_controller = node
+            return _cached_controller
+    if Engine.has_singleton("RNGProcessorController"):
+        var singleton := Engine.get_singleton("RNGProcessorController")
+        if _is_object_valid(singleton):
+            _cached_controller = singleton
+            return _cached_controller
+    return null
+
+func _get_metadata_service() -> Object:
+    if _metadata_service_override != null and _is_object_valid(_metadata_service_override):
+        return _metadata_service_override
+    if _cached_metadata_service != null and _is_object_valid(_cached_metadata_service):
+        return _cached_metadata_service
+    if metadata_service_path != NodePath("") and has_node(metadata_service_path):
+        var node := get_node(metadata_service_path)
+        if node != null:
+            _cached_metadata_service = node
+            return _cached_metadata_service
+    if Engine.has_singleton("StrategyMetadataService"):
+        var singleton := Engine.get_singleton("StrategyMetadataService")
+        if _is_object_valid(singleton):
+            _cached_metadata_service = singleton
+            return _cached_metadata_service
+    return null
+
+func _is_object_valid(candidate: Object) -> bool:
+    if candidate == null:
+        return false
+    if candidate is Node:
+        return is_instance_valid(candidate)
+    return true

--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.tscn
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.tscn
@@ -1,0 +1,143 @@
+[gd_scene load_steps=2 format=3 uid="uid://syllablechainpanel"]
+
+[ext_resource type="Script" path="res://addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd" id="1_w9vaf"]
+
+[node name="SyllableChainPanel" type="VBoxContainer"]
+custom_minimum_size = Vector2(520, 0)
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+theme_override_constants/separation = 12
+script = ExtResource("1_w9vaf")
+
+[node name="Header" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 8
+
+[node name="Title" type="Label" parent="Header"]
+theme_override_font_sizes/font_size = 18
+text = "Syllable Chain Strategy"
+
+[node name="HeaderSpacer" type="Control" parent="Header"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+[node name="RefreshButton" type="Button" parent="Header"]
+flat = true
+text = "Refresh"
+tooltip_text = "Reload strategy metadata and the resource catalogue."
+
+[node name="MetadataSummary" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = ""
+
+[node name="NotesLabel" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = ""
+
+[node name="ResourceSection" type="VBoxContainer" parent="."]
+theme_override_constants/separation = 4
+
+[node name="ResourceLabel" type="Label" parent="ResourceSection"]
+text = "Available syllable sets"
+
+[node name="ResourceList" type="ItemList" parent="ResourceSection"]
+allow_reselect = true
+allow_rmb_select = true
+custom_minimum_size = Vector2(0, 220)
+select_mode = ItemList.SELECT_SINGLE
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+[node name="ResourceSummary" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = "Select a syllable set to review its details."
+
+[node name="OptionsSection" type="VBoxContainer" parent="."]
+theme_override_constants/separation = 8
+
+[node name="RequireMiddle" type="CheckButton" parent="OptionsSection"]
+text = "Require at least one middle syllable"
+
+[node name="MiddleRangeRow" type="HBoxContainer" parent="OptionsSection"]
+theme_override_constants/separation = 6
+
+[node name="MiddleRangeLabel" type="Label" parent="OptionsSection/MiddleRangeRow"]
+text = "Middle syllable range"
+
+[node name="MiddleRangeSpacer" type="Control" parent="OptionsSection/MiddleRangeRow"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+[node name="MiddleMinLabel" type="Label" parent="OptionsSection/MiddleRangeRow"]
+text = "Min"
+
+[node name="MiddleMinSpin" type="SpinBox" parent="OptionsSection/MiddleRangeRow"]
+allow_lesser = true
+allow_greater = true
+custom_minimum_size = Vector2(80, 0)
+max_value = 32.0
+min_value = 0.0
+step = 1.0
+value = 0.0
+
+[node name="MiddleMaxLabel" type="Label" parent="OptionsSection/MiddleRangeRow"]
+text = "Max"
+
+[node name="MiddleMaxSpin" type="SpinBox" parent="OptionsSection/MiddleRangeRow"]
+allow_lesser = true
+allow_greater = true
+custom_minimum_size = Vector2(80, 0)
+max_value = 32.0
+min_value = 0.0
+step = 1.0
+value = 1.0
+
+[node name="MinLengthRow" type="HBoxContainer" parent="OptionsSection"]
+theme_override_constants/separation = 6
+
+[node name="MinLengthLabel" type="Label" parent="OptionsSection/MinLengthRow"]
+text = "Minimum length"
+
+[node name="MinLengthSpacer" type="Control" parent="OptionsSection/MinLengthRow"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+[node name="MinLengthSpin" type="SpinBox" parent="OptionsSection/MinLengthRow"]
+allow_lesser = true
+allow_greater = true
+custom_minimum_size = Vector2(120, 0)
+max_value = 64.0
+min_value = 0.0
+step = 1.0
+value = 0.0
+
+[node name="RegexSection" type="VBoxContainer" parent="OptionsSection"]
+theme_override_constants/separation = 4
+
+[node name="RegexLabel" type="Label" parent="OptionsSection/RegexSection"]
+text = "Regex cleanup presets"
+tooltip_text = "Select presets to post-process generated names before display."
+
+[node name="RegexPresetContainer" type="VBoxContainer" parent="OptionsSection/RegexSection"]
+theme_override_constants/separation = 2
+
+[node name="PreviewRow" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 12
+
+[node name="SeedLabel" type="Label" parent="PreviewRow"]
+text = "Seed"
+
+[node name="SeedInput" type="LineEdit" parent="PreviewRow"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+placeholder_text = "Optional seed label"
+
+[node name="PreviewButton" type="Button" parent="PreviewRow"]
+text = "Preview"
+
+[node name="ValidationLabel" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+self_modulate = Color(0.870588, 0.196078, 0.203922, 1)
+visible = false
+
+[node name="PreviewOutput" type="RichTextLabel" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+bbcode_enabled = true
+fit_content = true
+scroll_active = false
+visible = false

--- a/devdocs/platform_gui_handbook.md
+++ b/devdocs/platform_gui_handbook.md
@@ -34,6 +34,19 @@ Follow these steps whenever you need to work inside the Platform GUI:
 7. Press **Preview** to request a seeded sample from the middleware. Successful runs render the preview inline, while validation errors appear in red beneath the controls so you can correct the form without leaving the panel.
 8. Click **Refresh** if you add new word lists to the project mid-session. The button reloads both the metadata schema and the resource catalogue.
 
+### Configuring syllable chain strategies
+
+1. Choose **Syllable Chain** from the strategy dropdown to load the dedicated panel.
+2. Review the metadata banner and inline notes. They come directly from `describe_strategies()` so the panel mirrors the same schema the middleware validates against.
+3. Use the resource browser to pick a `SyllableSetResource`. Each entry summarises prefix/middle/suffix counts plus locale and domain tags so you can immediately judge coverage.
+4. Check the details panel beneath the list to confirm whether the resource allows empty middles. The panel automatically expands the middle syllable slider range to match the asset so you are never capped prematurely.
+5. Toggle **Require at least one middle syllable** to enforce bridge syllables. When enabled the panel clamps the minimum slider to 1 so the config cannot drift below what the middleware expects.
+6. Adjust the **Middle syllable range** sliders to control optional middles. Invalid ranges surface an inline validation message and the sliders tint red until corrected, matching the middleware error codes for quick debugging.
+7. Set a **Minimum length** if you want the strategy to append extra middles until the generated name crosses a threshold. Leave it at `0` to accept any length.
+8. Enable one or more **Regex cleanup presets** to strip stray punctuation or collapse awkward repeats after generation. The presets map to the `post_processing_rules` array in the strategy config so the middleware receives ready-to-run instructions.
+9. Supply an optional seed, then click **Preview**. Successful runs render seeded output inline. Middleware validation errors are echoed in red along with human-friendly hints from the metadata service (e.g., missing resources or invalid middle ranges) so you can course-correct immediately.
+10. Use **Refresh** whenever you add new syllable sets or need the latest schema hints; the button re-queries both the metadata service and the on-disk resource catalogue.
+
 ### Reviewing DebugRNG logs
 
 1. Switch to the **Debug Logs** tab. When DebugRNG is active, the middleware writes to `user://debug_rng_report.txt` (or a custom path you configured earlier).


### PR DESCRIPTION
## Summary
- add a dedicated syllable chain configuration panel with metadata-aware validation and seeded previews
- surface regex cleanup presets and highlight middle-range/resource issues based on middleware responses
- document the new workflow in the platform GUI handbook for artists

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb727cb8948320b77c07a6e169fd26