### PR TITLE
Add template strategy panel with metadata-driven validation

### DIFF
--- a/addons/platform_gui/panels/template/TemplatePanel.gd
+++ b/addons/platform_gui/panels/template/TemplatePanel.gd
@@ -1,0 +1,568 @@
+extends VBoxContainer
+
+## Platform GUI panel that configures TemplateStrategy instances.
+##
+## The panel parses author-provided template strings, visualises the resulting
+## token tree, and surfaces validation hints sourced from the middleware's
+## metadata cache. Configuration controls mirror TemplateStrategy's schema,
+## including support for nested sub-generator dictionaries and configurable
+## recursion limits. The widget mirrors the behaviour exposed by the other
+## strategy panels so it can be dropped into existing editor hierarchies
+## without additional wiring.
+
+@export var controller_path: NodePath
+@export var metadata_service_path: NodePath
+
+const TEMPLATE_STRATEGY_ID := "template"
+const TOKEN_PATTERN := "\\[(?<token>[^\\[\\]]+)\\]"
+const DEFAULT_MAX_DEPTH := 8
+const _ERROR_TINT := Color(1.0, 0.85, 0.85, 1.0)
+
+@onready var _metadata_summary: Label = %MetadataSummary
+@onready var _notes_label: Label = %NotesLabel
+@onready var _template_input: TextEdit = %TemplateInput
+@onready var _max_depth_spin: SpinBox = %MaxDepthSpin
+@onready var _seed_edit: LineEdit = %SeedInput
+@onready var _seed_helper: Label = %SeedHelper
+@onready var _sub_generators_edit: TextEdit = %SubGeneratorInput
+@onready var _token_tree: Tree = %TokenTree
+@onready var _validation_label: Label = %ValidationLabel
+@onready var _fix_it_label: Label = %FixItLabel
+@onready var _preview_button: Button = %PreviewButton
+@onready var _preview_label: RichTextLabel = %PreviewOutput
+
+var _controller_override: Object = null
+var _cached_controller: Object = null
+var _metadata_service_override: Object = null
+var _cached_metadata_service: Object = null
+var _control_default_modulates: Dictionary = {}
+var _token_regex: RegEx = null
+
+func _ready() -> void:
+    _preview_button.pressed.connect(_on_preview_button_pressed)
+    %RefreshButton.pressed.connect(_on_refresh_pressed)
+    _template_input.text_changed.connect(_on_template_changed)
+    _sub_generators_edit.text_changed.connect(_on_sub_generators_changed)
+    _max_depth_spin.value_changed.connect(_on_max_depth_changed)
+    _seed_edit.text_changed.connect(_on_seed_changed)
+    _token_tree.set_column_titles_visible(true)
+    _token_tree.set_column_title(0, "Node")
+    _token_tree.set_column_title(1, "Depth")
+    _token_tree.set_column_title(2, "Strategy")
+    _token_tree.set_column_title(3, "Seed")
+    _track_default_modulate(_template_input)
+    _track_default_modulate(_sub_generators_edit)
+    _track_default_modulate(_max_depth_spin)
+    _track_default_modulate(_token_tree)
+    _refresh_metadata()
+    _update_seed_helper()
+    _rebuild_configuration_views()
+
+func set_controller_override(controller: Object) -> void:
+    _controller_override = controller
+    _cached_controller = null
+    _update_seed_helper()
+
+func set_metadata_service_override(service: Object) -> void:
+    _metadata_service_override = service
+    _cached_metadata_service = null
+    _refresh_metadata()
+    _rebuild_configuration_views()
+
+func refresh() -> void:
+    _refresh_metadata()
+    _rebuild_configuration_views()
+    _update_seed_helper()
+
+func build_config_payload() -> Dictionary:
+    var config: Dictionary = {
+        "strategy": TEMPLATE_STRATEGY_ID,
+        "template_string": _template_input.text,
+    }
+    var max_depth := int(_max_depth_spin.value)
+    if max_depth != DEFAULT_MAX_DEPTH:
+        config["max_depth"] = max_depth
+    var seed_value := _seed_edit.text.strip_edges()
+    if seed_value != "":
+        config["seed"] = seed_value
+    var sub_generators := _parse_sub_generator_dictionary()
+    if not sub_generators.is_empty():
+        config["sub_generators"] = sub_generators
+    return config
+
+func get_child_generator_definitions() -> Dictionary:
+    return _parse_sub_generator_dictionary()
+
+func _on_refresh_pressed() -> void:
+    refresh()
+
+func _on_template_changed() -> void:
+    _rebuild_configuration_views()
+
+func _on_sub_generators_changed() -> void:
+    _rebuild_configuration_views()
+
+func _on_max_depth_changed(_value: float) -> void:
+    _rebuild_configuration_views()
+
+func _on_seed_changed(_text: String) -> void:
+    _rebuild_configuration_views()
+    _update_seed_helper()
+
+func _on_preview_button_pressed() -> void:
+    var controller := _get_controller()
+    if controller == null:
+        _update_preview_state({
+            "status": "error",
+            "message": "RNGProcessor controller unavailable.",
+        })
+        return
+
+    var evaluation := _evaluate_configuration()
+    _render_token_tree(evaluation["structure"])
+    _apply_validation_feedback(evaluation["errors"])
+    if not evaluation["errors"].is_empty():
+        _update_preview_state({
+            "status": "error",
+            "message": String(evaluation["errors"][0].get("message", "Template configuration contains errors.")),
+        })
+        return
+
+    var config := build_config_payload()
+    var response: Variant = controller.call("generate", config)
+    if response is Dictionary and response.has("code"):
+        var error_dict: Dictionary = response
+        var message := String(error_dict.get("message", "Generation failed."))
+        var hint := _lookup_error_hint(String(error_dict.get("code", "")))
+        if hint != "":
+            message += "\n%s" % hint
+        _update_preview_state({
+            "status": "error",
+            "message": message,
+            "details": error_dict.get("details", {}),
+        })
+        _update_seed_helper()
+        return
+
+    _update_preview_state({
+        "status": "success",
+        "message": String(response),
+    })
+    _update_seed_helper()
+
+func _refresh_metadata() -> void:
+    var service := _get_metadata_service()
+    if service == null:
+        _metadata_summary.text = "Template strategy metadata unavailable."
+        _notes_label.text = ""
+        return
+
+    var required := PackedStringArray()
+    if service.has_method("get_required_keys"):
+        required = service.call("get_required_keys", TEMPLATE_STRATEGY_ID)
+    var optional: Dictionary = {}
+    if service.has_method("get_optional_key_types"):
+        optional = service.call("get_optional_key_types", TEMPLATE_STRATEGY_ID)
+
+    var summary_parts := []
+    if required.size() > 0:
+        summary_parts.append("Required: %s" % ", ".join(required))
+    if not optional.is_empty():
+        var optional_keys := PackedStringArray()
+        for key in optional.keys():
+            optional_keys.append(String(key))
+        optional_keys.sort()
+        summary_parts.append("Optional: %s" % ", ".join(optional_keys))
+    _metadata_summary.text = " | ".join(summary_parts)
+
+    var notes := PackedStringArray()
+    if service.has_method("get_default_notes"):
+        notes = service.call("get_default_notes", TEMPLATE_STRATEGY_ID)
+    if notes.size() > 0:
+        _notes_label.text = "\n".join(notes)
+    else:
+        _notes_label.text = ""
+
+func _update_seed_helper() -> void:
+    var controller := _get_controller()
+    var latest_metadata := {}
+    if controller != null and controller.has_method("get_latest_generation_metadata"):
+        latest_metadata = controller.call("get_latest_generation_metadata")
+    var stream_hint := String(latest_metadata.get("rng_stream", ""))
+    var seed_hint := String(latest_metadata.get("seed", ""))
+    var helper_lines := ["Child seeds derive automatically as parent::token::occurrence."]
+    if stream_hint != "" or seed_hint != "":
+        helper_lines.append("Latest middleware seed: %s" % (seed_hint if seed_hint != "" else "—"))
+        helper_lines.append("Latest middleware stream: %s" % (stream_hint if stream_hint != "" else "—"))
+    _seed_helper.text = "\n".join(helper_lines)
+
+func _rebuild_configuration_views() -> void:
+    var evaluation := _evaluate_configuration()
+    _render_token_tree(evaluation["structure"])
+    _apply_validation_feedback(evaluation["errors"])
+
+func _evaluate_configuration() -> Dictionary:
+    var template_string := _template_input.text
+    var max_depth := int(_max_depth_spin.value)
+    var seed_value := _seed_edit.text.strip_edges()
+    var errors: Array = []
+
+    if max_depth <= 0:
+        errors.append({
+            "code": "invalid_max_depth",
+            "message": "Configuration value for 'max_depth' must be greater than zero.",
+            "target": "max_depth",
+        })
+        max_depth = 1
+
+    var parse_result := _parse_sub_generators()
+    errors.append_array(parse_result["errors"])
+    var sub_generators: Dictionary = parse_result["definitions"]
+
+    var structure := _build_token_structure(template_string, sub_generators, 0, max_depth, seed_value)
+    errors.append_array(structure["errors"])
+
+    return {
+        "structure": structure["node"],
+        "errors": errors,
+    }
+
+func _parse_sub_generators() -> Dictionary:
+    var errors: Array = []
+    var definitions: Dictionary = {}
+    var text := _sub_generators_edit.text.strip_edges()
+    if text == "":
+        return {"errors": errors, "definitions": definitions}
+
+    var json := JSON.new()
+    var parse_error := json.parse(text)
+    if parse_error != OK:
+        errors.append({
+            "code": "invalid_json",
+            "message": "Child generator definitions must be valid JSON (error at line %d)." % (json.get_error_line()),
+            "target": "sub_generators",
+        })
+        return {"errors": errors, "definitions": definitions}
+
+    var data: Variant = json.data
+    if typeof(data) != TYPE_DICTIONARY:
+        errors.append({
+            "code": "invalid_sub_generators_type",
+            "message": "TemplateStrategy optional 'sub_generators' must be a Dictionary.",
+            "target": "sub_generators",
+        })
+        return {"errors": errors, "definitions": definitions}
+
+    definitions = (data as Dictionary).duplicate(true)
+    return {"errors": errors, "definitions": definitions}
+
+func _parse_sub_generator_dictionary() -> Dictionary:
+    var result := _parse_sub_generators()
+    return result["definitions"]
+
+func _build_token_structure(
+    template_string: String,
+    sub_generators: Dictionary,
+    depth: int,
+    max_depth: int,
+    parent_seed: String
+) -> Dictionary:
+    var structure := {
+        "node_type": "template",
+        "template": template_string,
+        "depth": depth,
+        "seed": parent_seed,
+        "children": [],
+    }
+    var errors: Array = []
+
+    var regex := _get_token_regex()
+    var matches := regex.search_all(template_string)
+    var token_counts: Dictionary = {}
+    for match in matches:
+        var token_raw := _extract_token(match)
+        var token := token_raw.strip_edges()
+        var start_index := match.get_start()
+        var occurrence := int(token_counts.get(token, 0))
+        token_counts[token] = occurrence + 1
+
+        var token_node := {
+            "node_type": "token",
+            "token": token,
+            "occurrence": occurrence,
+            "depth": depth + 1,
+            "seed": "%s::%s::%d" % [String(parent_seed), token, occurrence],
+            "strategy": "",
+            "display_name": "",
+            "children": [],
+            "errors": [],
+        }
+
+        if token == "":
+            var empty_error := {
+                "code": "empty_token",
+                "message": "Template token at index %d must specify a sub-generator key." % start_index,
+                "target": "template",
+            }
+            token_node["errors"].append(empty_error)
+            errors.append(empty_error)
+        elif not sub_generators.has(token):
+            var missing_error := {
+                "code": "missing_template_token",
+                "message": "Template token '%s' does not have a configured sub-generator." % token,
+                "target": "template",
+            }
+            token_node["errors"].append(missing_error)
+            errors.append(missing_error)
+        else:
+            var generator_config_variant := sub_generators[token]
+            if typeof(generator_config_variant) != TYPE_DICTIONARY:
+                var type_error := {
+                    "code": "invalid_config_type",
+                    "message": "sub_generators['%s'] must be provided as a Dictionary." % token,
+                    "target": "sub_generators",
+                }
+                token_node["errors"].append(type_error)
+                errors.append(type_error)
+            else:
+                var generator_config: Dictionary = (generator_config_variant as Dictionary).duplicate(true)
+                var strategy_id := String(generator_config.get("strategy", "")).strip_edges()
+                token_node["strategy"] = strategy_id
+                token_node["display_name"] = _resolve_strategy_display_name(strategy_id)
+
+                if generator_config.has("seed"):
+                    token_node["seed"] = String(generator_config["seed"])
+
+                var inherited_max_depth := max_depth
+                if generator_config.has("max_depth"):
+                    inherited_max_depth = int(generator_config["max_depth"])
+                    if inherited_max_depth <= 0:
+                        var child_max_depth_error := {
+                            "code": "invalid_max_depth",
+                            "message": "Configuration value for 'max_depth' must be greater than zero.",
+                            "target": "sub_generators",
+                        }
+                        token_node["errors"].append(child_max_depth_error)
+                        errors.append(child_max_depth_error)
+
+                if token_node["depth"] >= inherited_max_depth:
+                    var depth_error := {
+                        "code": "template_recursion_depth_exceeded",
+                        "message": "Template expansion exceeded the allowed recursion depth (token '%s')." % token,
+                        "target": "max_depth",
+                    }
+                    token_node["errors"].append(depth_error)
+                    errors.append(depth_error)
+                elif strategy_id == TEMPLATE_STRATEGY_ID:
+                    var nested_template := String(generator_config.get("template_string", ""))
+                    var nested_sub_generators_variant: Variant = generator_config.get("sub_generators", {})
+                    var nested_sub_generators: Dictionary = {}
+                    if nested_sub_generators_variant is Dictionary:
+                        nested_sub_generators = (nested_sub_generators_variant as Dictionary).duplicate(true)
+                    var nested := _build_token_structure(
+                        nested_template,
+                        nested_sub_generators,
+                        token_node["depth"],
+                        inherited_max_depth,
+                        token_node["seed"],
+                    )
+                    token_node["children"].append(nested["node"])
+                    errors.append_array(nested["errors"])
+                elif strategy_id == "":
+                    var missing_strategy_error := {
+                        "code": "missing_strategy",
+                        "message": "Child generator for token '%s' must provide a 'strategy' key." % token,
+                        "target": "sub_generators",
+                    }
+                    token_node["errors"].append(missing_strategy_error)
+                    errors.append(missing_strategy_error)
+        structure["children"].append(token_node)
+    return {"node": structure, "errors": errors}
+
+func _render_token_tree(structure: Dictionary) -> void:
+    _token_tree.clear()
+    var root := _token_tree.create_item()
+    if structure.is_empty():
+        return
+    var template_item := _token_tree.create_item(root)
+    template_item.set_text(0, "Template")
+    template_item.set_text(1, str(structure.get("depth", 0)))
+    template_item.set_text(2, _resolve_strategy_display_name(TEMPLATE_STRATEGY_ID))
+    template_item.set_text(3, String(structure.get("seed", "")))
+    template_item.set_tooltip_text(0, structure.get("template", ""))
+    template_item.collapsed = false
+    _populate_token_children(template_item, structure.get("children", []))
+
+func _populate_token_children(parent: TreeItem, children: Array) -> void:
+    for child_dict in children:
+        if not (child_dict is Dictionary):
+            continue
+        var child: Dictionary = child_dict
+        if child.get("node_type", "") == "template":
+            var template_item := _token_tree.create_item(parent)
+            template_item.set_text(0, "Nested template")
+            template_item.set_text(1, str(child.get("depth", 0)))
+            template_item.set_text(2, _resolve_strategy_display_name(TEMPLATE_STRATEGY_ID))
+            template_item.set_text(3, String(child.get("seed", "")))
+            template_item.set_tooltip_text(0, child.get("template", ""))
+            _populate_token_children(template_item, child.get("children", []))
+            continue
+
+        var token_item := _token_tree.create_item(parent)
+        token_item.set_text(0, "[%s] (x%d)" % [String(child.get("token", "")), int(child.get("occurrence", 0)) + 1])
+        token_item.set_text(1, str(child.get("depth", 0)))
+        var display_name := String(child.get("display_name", ""))
+        var strategy_id := String(child.get("strategy", ""))
+        if display_name == "" and strategy_id != "":
+            display_name = strategy_id.capitalize()
+        token_item.set_text(2, display_name)
+        token_item.set_tooltip_text(2, strategy_id if strategy_id != "" else "Unmapped token")
+        token_item.set_text(3, String(child.get("seed", "")))
+
+        var errors: Array = child.get("errors", [])
+        if not errors.is_empty():
+            token_item.set_custom_color(0, Color(0.8, 0.2, 0.2))
+            var tooltips := []
+            for error in errors:
+                tooltips.append(String(error.get("message", "")))
+            token_item.set_tooltip_text(0, "\n".join(tooltips))
+        _populate_token_children(token_item, child.get("children", []))
+
+func _apply_validation_feedback(errors: Array) -> void:
+    _validation_label.visible = false
+    _validation_label.text = ""
+    _fix_it_label.visible = false
+    _fix_it_label.text = ""
+    _set_control_highlight(_template_input, false)
+    _set_control_highlight(_sub_generators_edit, false)
+    _set_control_highlight(_max_depth_spin, false)
+
+    if errors.is_empty():
+        return
+
+    var primary := errors[0]
+    _validation_label.visible = true
+    _validation_label.text = String(primary.get("message", "Template configuration invalid."))
+
+    var hint_messages := []
+    for error in errors:
+        var hint := _lookup_error_hint(String(error.get("code", "")))
+        if hint == "":
+            continue
+        if hint_messages.has(hint):
+            continue
+        hint_messages.append(hint)
+    if not hint_messages.is_empty():
+        _fix_it_label.visible = true
+        _fix_it_label.text = "\n".join(hint_messages)
+
+    for error in errors:
+        match String(error.get("target", "")):
+            "template":
+                _set_control_highlight(_template_input, true)
+            "sub_generators":
+                _set_control_highlight(_sub_generators_edit, true)
+            "max_depth":
+                _set_control_highlight(_max_depth_spin, true)
+
+func _update_preview_state(payload: Dictionary) -> void:
+    _preview_label.visible = false
+    _preview_label.text = ""
+    if payload == null:
+        return
+    var status := String(payload.get("status", ""))
+    var message := String(payload.get("message", ""))
+    if status == "success":
+        _validation_label.visible = false
+        _preview_label.visible = true
+        _preview_label.text = "[b]Preview:[/b]\n%s" % message
+    else:
+        _validation_label.visible = true
+        _validation_label.text = message
+
+func _lookup_error_hint(code: String) -> String:
+    if code == "" or code == "invalid_json":
+        return ""
+    var service := _get_metadata_service()
+    if service != null and service.has_method("get_generator_error_hint"):
+        return String(service.call("get_generator_error_hint", TEMPLATE_STRATEGY_ID, code))
+    return ""
+
+func _track_default_modulate(control: Control) -> void:
+    if control == null:
+        return
+    _control_default_modulates[control] = control.self_modulate
+
+func _set_control_highlight(control: Control, highlight: bool) -> void:
+    if control == null:
+        return
+    if highlight:
+        control.self_modulate = _ERROR_TINT
+    elif _control_default_modulates.has(control):
+        control.self_modulate = _control_default_modulates[control]
+
+func _resolve_strategy_display_name(strategy_id: String) -> String:
+    if strategy_id == "":
+        return ""
+    var service := _get_metadata_service()
+    if service == null:
+        return strategy_id
+    if service.has_method("get_strategy_metadata"):
+        var metadata: Dictionary = service.call("get_strategy_metadata", strategy_id)
+        if metadata.has("display_name"):
+            return String(metadata["display_name"])
+    return strategy_id
+
+func _get_token_regex() -> RegEx:
+    if _token_regex == null:
+        _token_regex = RegEx.new()
+        var error := _token_regex.compile(TOKEN_PATTERN)
+        if error != OK:
+            push_error("Failed to compile template token pattern: %s" % TOKEN_PATTERN)
+    return _token_regex
+
+func _extract_token(match: RegExMatch) -> String:
+    if match.names.has("token"):
+        return match.get_string("token")
+    return match.get_string(1)
+
+func _get_controller() -> Object:
+    if _controller_override != null and _is_object_valid(_controller_override):
+        return _controller_override
+    if _cached_controller != null and _is_object_valid(_cached_controller):
+        return _cached_controller
+    if controller_path != NodePath("") and has_node(controller_path):
+        var node := get_node(controller_path)
+        if node != null:
+            _cached_controller = node
+            return _cached_controller
+    if Engine.has_singleton("RNGProcessorController"):
+        var singleton := Engine.get_singleton("RNGProcessorController")
+        if _is_object_valid(singleton):
+            _cached_controller = singleton
+            return _cached_controller
+    return null
+
+func _get_metadata_service() -> Object:
+    if _metadata_service_override != null and _is_object_valid(_metadata_service_override):
+        return _metadata_service_override
+    if _cached_metadata_service != null and _is_object_valid(_cached_metadata_service):
+        return _cached_metadata_service
+    if metadata_service_path != NodePath("") and has_node(metadata_service_path):
+        var node := get_node(metadata_service_path)
+        if node != null:
+            _cached_metadata_service = node
+            return _cached_metadata_service
+    if Engine.has_singleton("StrategyMetadataService"):
+        var singleton := Engine.get_singleton("StrategyMetadataService")
+        if _is_object_valid(singleton):
+            _cached_metadata_service = singleton
+            return _cached_metadata_service
+    return null
+
+func _is_object_valid(candidate: Object) -> bool:
+    if candidate == null:
+        return false
+    if candidate is Node:
+        return is_instance_valid(candidate)
+    return true

--- a/addons/platform_gui/panels/template/TemplatePanel.tscn
+++ b/addons/platform_gui/panels/template/TemplatePanel.tscn
@@ -1,0 +1,119 @@
+[gd_scene load_steps=2 format=3 uid="uid://templatepanel"]
+
+[ext_resource type="Script" path="res://addons/platform_gui/panels/template/TemplatePanel.gd" id="1_zl6r1"]
+
+[node name="TemplatePanel" type="VBoxContainer"]
+custom_minimum_size = Vector2(520, 0)
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+theme_override_constants/separation = 12
+script = ExtResource("1_zl6r1")
+
+[node name="Header" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 8
+
+[node name="Title" type="Label" parent="Header"]
+theme_override_font_sizes/font_size = 18
+text = "Template Strategy"
+
+[node name="HeaderSpacer" type="Control" parent="Header"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+[node name="RefreshButton" type="Button" parent="Header"]
+flat = true
+text = "Refresh"
+tooltip_text = "Reload strategy metadata."
+
+[node name="MetadataSummary" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = ""
+
+[node name="NotesLabel" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = ""
+
+[node name="TemplateSection" type="VBoxContainer" parent="."]
+theme_override_constants/separation = 4
+
+[node name="TemplateLabel" type="Label" parent="TemplateSection"]
+text = "Template string"
+
+[node name="TemplateInput" type="TextEdit" parent="TemplateSection"]
+custom_minimum_size = Vector2(0, 80)
+placeholder_text = "Forge a [material] blade for the [title]."
+scroll_fit_content_height = true
+wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+
+[node name="MaxDepthRow" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 8
+
+[node name="MaxDepthLabel" type="Label" parent="MaxDepthRow"]
+text = "Max depth"
+
+[node name="MaxDepthSpin" type="SpinBox" parent="MaxDepthRow"]
+custom_minimum_size = Vector2(120, 0)
+max_value = 64.0
+min_value = 1.0
+step = 1.0
+value = 8.0
+
+[node name="SeedRow" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 8
+
+[node name="SeedLabel" type="Label" parent="SeedRow"]
+text = "Seed"
+
+[node name="SeedInput" type="LineEdit" parent="SeedRow"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+placeholder_text = "Optional seed label"
+
+[node name="SeedHelper" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+text = "Child seeds derive automatically as parent::token::occurrence."
+
+[node name="SubGeneratorSection" type="VBoxContainer" parent="."]
+theme_override_constants/separation = 4
+
+[node name="SubGeneratorLabel" type="Label" parent="SubGeneratorSection"]
+text = "Child generator definitions (JSON)"
+
+[node name="SubGeneratorInput" type="TextEdit" parent="SubGeneratorSection"]
+custom_minimum_size = Vector2(0, 140)
+placeholder_text = "{\n    \"material\": {\"strategy\": \"wordlist\", \"wordlist_paths\": []},\n    \"title\": {\"strategy\": \"template\", \"template_string\": \"[rank] of [order]\"}\n}"
+scroll_fit_content_height = true
+wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+
+[node name="TokenTreeLabel" type="Label" parent="."]
+text = "Token expansion preview"
+
+[node name="TokenTree" type="Tree" parent="."]
+columns = 4
+custom_minimum_size = Vector2(0, 220)
+select_mode = Tree.SELECT_ROW
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+[node name="ValidationLabel" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+self_modulate = Color(0.870588, 0.196078, 0.203922, 1)
+visible = false
+
+[node name="FixItLabel" type="Label" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+visible = false
+
+[node name="PreviewRow" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 12
+
+[node name="PreviewButton" type="Button" parent="PreviewRow"]
+text = "Preview"
+
+[node name="PreviewSpacer" type="Control" parent="PreviewRow"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+[node name="PreviewOutput" type="RichTextLabel" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+bbcode_enabled = true
+fit_content = true
+scroll_active = false
+visible = false

--- a/devdocs/platform_gui_handbook.md
+++ b/devdocs/platform_gui_handbook.md
@@ -47,6 +47,17 @@ Follow these steps whenever you need to work inside the Platform GUI:
 9. Supply an optional seed, then click **Preview**. Successful runs render seeded output inline. Middleware validation errors are echoed in red along with human-friendly hints from the metadata service (e.g., missing resources or invalid middle ranges) so you can course-correct immediately.
 10. Use **Refresh** whenever you add new syllable sets or need the latest schema hints; the button re-queries both the metadata service and the on-disk resource catalogue.
 
+### Configuring template strategies
+
+1. Choose **Template** from the strategy dropdown to load the dedicated panel.
+2. Scan the metadata banner and helper notes sourced from `describe_strategies()`. They recap the required keys (`template_string`, `sub_generators`) and optional settings (`max_depth`, `seed`) so you can line up the config with middleware expectations.
+3. Enter your template in the **Template string** field. Tokens wrapped in brackets (e.g. `[material]`) immediately appear in the token tree below so you can confirm the parser understands the structure.
+4. Define child generators in the **Child generator definitions** JSON editor. Each entry should mirror a `NameGenerator.generate` payload. The panel validates the JSON as you type and highlights any tokens that do not have a matching sub-generator configuration.
+5. Adjust **Max depth** when you need deeper recursion than the default `8`. The live validator mirrors TemplateStrategy's `template_recursion_depth_exceeded` guard, tinting the control red and surfacing the middleware's fix-it hint when the tree would breach the limit.
+6. Supply an optional seed label; the **Seed helper** banner illustrates the derived seed path (`parent::token::occurrence`) and pulls the latest middleware seed/stream from `RNGProcessorController.get_latest_generation_metadata()` for extra context.
+7. Review the **Token expansion preview** tree. Each row lists the recursion depth, resolved strategy display name, and the seed that TemplateStrategy will pass to the child generator. Nested template configs expand inline so you can verify cascaded definitions without leaving the panel.
+8. Press **Preview** to request a deterministic sample. Middleware validation errors reuse the metadata service's guidance (for example, empty tokens or missing strategy keys) so the fix is always spelled out next to the relevant control.
+
 ### Reviewing DebugRNG logs
 
 1. Switch to the **Debug Logs** tab. When DebugRNG is active, the middleware writes to `user://debug_rng_report.txt` (or a custom path you configured earlier).

--- a/name_generator/strategies/TemplateStrategy.gd
+++ b/name_generator/strategies/TemplateStrategy.gd
@@ -264,7 +264,15 @@ func describe() -> Dictionary:
         "Provide max_depth to guard against accidental infinite recursion.",
         "Seed values cascade to child generators when omitted from sub-configs.",
     ])
+    var error_hints := {
+        "empty_token": "Populate every [token] with a name so it can map to a sub-generator.",
+        "missing_template_token": "Add matching entries to sub_generators for each template token.",
+        "template_recursion_depth_exceeded": "Increase max_depth or simplify nested templates to avoid infinite recursion.",
+        "invalid_max_depth": "Set max_depth to a positive integer before generating.",
+        "missing_strategy": "Each sub-generator must include a 'strategy' key before it can generate.",
+    }
     return {
         "expected_config": get_config_schema(),
         "notes": notes,
+        "error_hints": error_hints,
     }


### PR DESCRIPTION
## Summary
- add a Template strategy platform panel with template parsing, token tree visualisation, and metadata-backed validation hints
- surface middleware error guidance by extending TemplateStrategy metadata and wiring fix-it copy into the panel UI
- refresh the platform GUI handbook to document the new Template workflow and helper seed guidance

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7453418083209f787ba0e7e977d8