### PR TITLE
Add Formulas workspace and seed propagation cues

### DIFF
--- a/addons/platform_gui/panels/wordlist/WordlistPanel.gd
+++ b/addons/platform_gui/panels/wordlist/WordlistPanel.gd
@@ -90,6 +90,32 @@ func build_config_payload() -> Dictionary:
         config["seed"] = seed_value
     return config
 
+func apply_config_payload(config: Dictionary) -> void:
+    var delimiter := String(config.get("delimiter", ""))
+    if _delimiter_edit.text != delimiter:
+        _delimiter_edit.text = delimiter
+    var use_weights := bool(config.get("use_weights", false))
+    if _weight_toggle.button_pressed != use_weights:
+        _weight_toggle.button_pressed = use_weights
+    var seed_value := String(config.get("seed", ""))
+    if _seed_edit.text != seed_value:
+        _seed_edit.text = seed_value
+    var target_paths: Array[String] = []
+    var paths_variant := config.get("wordlist_paths", [])
+    if paths_variant is Array:
+        for entry in paths_variant:
+            target_paths.append(String(entry))
+    _resource_list.deselect_all()
+    if not target_paths.is_empty():
+        for index in range(_resource_list.item_count):
+            var metadata: Dictionary = _resource_list.get_item_metadata(index)
+            if not (metadata is Dictionary):
+                continue
+            var path := String(metadata.get("path", ""))
+            if target_paths.has(path):
+                _resource_list.select(index)
+    _update_preview_state(null)
+
 func _on_refresh_pressed() -> void:
     refresh()
 

--- a/addons/platform_gui/workspaces/formulas/FormulasWorkspace.gd
+++ b/addons/platform_gui/workspaces/formulas/FormulasWorkspace.gd
@@ -1,0 +1,498 @@
+extends VBoxContainer
+
+## Top-level workspace scene that guides artists through assembling
+## hybrid-template formulas documented in `devdocs/sentences.md`.
+##
+## The workspace bundles curated blueprints, loads matching HybridStrategy
+## and TemplateStrategy configurations, and visualises how seeds and aliases
+## propagate through the combined pipeline. Inline help links directly to
+## handbook anchors so narrative artists can cross-reference the underlying
+## examples without leaving the editor.
+
+@export var controller_path: NodePath
+@export var metadata_service_path: NodePath
+@export var handbook_path: String = "res://devdocs/platform_gui_handbook.md"
+
+const SENTENCE_DOC_PATH := "res://devdocs/sentences.md"
+const _ERROR_TINT := Color(1.0, 0.9, 0.9, 1.0)
+const _INFO_TINT := Color(0.9, 0.97, 1.0, 1.0)
+
+const BLUEPRINTS := [
+    {
+        "id": "skill_sentence",
+        "display_name": "Skill sentence (hybrid + nested template)",
+        "description": "Chains verb and theme word lists before resolving a nested template that stitches the payload together.",
+        "handbook_anchor": "skill-description-sentence-template-inside-hybrid",
+        "template_step_alias": "skill_sentence",
+        "notes": [
+            "Word lists live in res://data/wordlists/skills/ to mirror the devdocs example.",
+            "Hybrid seed prefixes (skill_sentence_v1::step_$alias) keep previews deterministic when reusing payloads.",
+        ],
+        "hybrid": {
+            "strategy": "hybrid",
+            "seed": "skill_sentence_v1",
+            "steps": [
+                {
+                    "store_as": "skill_verb",
+                    "config": {
+                        "strategy": "wordlist",
+                        "wordlist_paths": ["res://data/wordlists/skills/skill_verbs.tres"],
+                    },
+                },
+                {
+                    "store_as": "skill_theme",
+                    "config": {
+                        "strategy": "wordlist",
+                        "wordlist_paths": ["res://data/wordlists/skills/skill_themes.tres"],
+                    },
+                },
+                {
+                    "store_as": "skill_sentence",
+                    "config": {
+                        "strategy": "template",
+                        "template_string": "[skill_sentence]",
+                        "sub_generators": {
+                            "skill_sentence": {
+                                "strategy": "template",
+                                "template_string": "The $skill_verb of $skill_theme [skill_payload]",
+                                "sub_generators": {
+                                    "skill_payload": {
+                                        "strategy": "wordlist",
+                                        "wordlist_paths": ["res://data/wordlists/skills/skill_payloads.tres"],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+            "template": "$skill_sentence",
+        },
+        "template": {
+            "strategy": "template",
+            "template_string": "[skill_sentence]",
+            "sub_generators": {
+                "skill_sentence": {
+                    "strategy": "template",
+                    "template_string": "The $skill_verb of $skill_theme [skill_payload]",
+                    "sub_generators": {
+                        "skill_payload": {
+                            "strategy": "wordlist",
+                            "wordlist_paths": ["res://data/wordlists/skills/skill_payloads.tres"],
+                        },
+                    },
+                },
+            },
+        },
+    },
+    {
+        "id": "faction_mission",
+        "display_name": "Faction mission brief",
+        "description": "Builds a faction name, then layers a three-part mission hook with deterministic twists.",
+        "handbook_anchor": "faction-mission-blurb-hybrid-with-nested-templates",
+        "template_step_alias": "mission_body",
+        "notes": [
+            "All mission lists live under res://data/wordlists/factions/ so pipeline paths stay consistent with the handbook.",
+            "Nested templates inherit the mission seed to guarantee matching verbs, targets, and twists during iteration.",
+        ],
+        "hybrid": {
+            "strategy": "hybrid",
+            "seed": "faction_mission_demo",
+            "steps": [
+                {
+                    "store_as": "faction",
+                    "config": {
+                        "strategy": "wordlist",
+                        "wordlist_paths": ["res://data/wordlists/factions/faction_titles.tres"],
+                    },
+                },
+                {
+                    "store_as": "mission_body",
+                    "config": {
+                        "strategy": "template",
+                        "template_string": "[mission_body]",
+                        "max_depth": 5,
+                        "sub_generators": {
+                            "mission_body": {
+                                "strategy": "template",
+                                "template_string": "$faction must [mission_action]",
+                                "sub_generators": {
+                                    "mission_action": {
+                                        "strategy": "template",
+                                        "template_string": "[mission_verb] [mission_target] [mission_twist]",
+                                        "sub_generators": {
+                                            "mission_verb": {
+                                                "strategy": "wordlist",
+                                                "wordlist_paths": ["res://data/wordlists/factions/mission_verbs.tres"],
+                                            },
+                                            "mission_target": {
+                                                "strategy": "wordlist",
+                                                "wordlist_paths": ["res://data/wordlists/factions/mission_targets.tres"],
+                                            },
+                                            "mission_twist": {
+                                                "strategy": "wordlist",
+                                                "wordlist_paths": ["res://data/wordlists/factions/mission_twists.tres"],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+            "template": "$mission_body",
+        },
+        "template": {
+            "strategy": "template",
+            "max_depth": 5,
+            "template_string": "[mission_body]",
+            "sub_generators": {
+                "mission_body": {
+                    "strategy": "template",
+                    "template_string": "$faction must [mission_action]",
+                    "sub_generators": {
+                        "mission_action": {
+                            "strategy": "template",
+                            "template_string": "[mission_verb] [mission_target] [mission_twist]",
+                            "sub_generators": {
+                                "mission_verb": {
+                                    "strategy": "wordlist",
+                                    "wordlist_paths": ["res://data/wordlists/factions/mission_verbs.tres"],
+                                },
+                                "mission_target": {
+                                    "strategy": "wordlist",
+                                    "wordlist_paths": ["res://data/wordlists/factions/mission_targets.tres"],
+                                },
+                                "mission_twist": {
+                                    "strategy": "wordlist",
+                                    "wordlist_paths": ["res://data/wordlists/factions/mission_twists.tres"],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+]
+
+var _controller_override: Object = null
+var _cached_controller: Object = null
+var _metadata_service_override: Object = null
+var _cached_metadata_service: Object = null
+var _current_blueprint_id: String = ""
+var _blueprint_lookup: Dictionary = {}
+
+@onready var _blueprint_selector: OptionButton = %BlueprintSelector
+@onready var _blueprint_notes: RichTextLabel = %BlueprintNotes
+@onready var _handbook_link: RichTextLabel = %HandbookLink
+@onready var _seed_tree: Tree = %PropagationTree
+@onready var _hybrid_panel: Control = %HybridPanel
+@onready var _template_panel: Control = %TemplatePanel
+@onready var _preview_button: Button = %PreviewButton
+@onready var _preview_label: RichTextLabel = %PreviewLabel
+
+func _ready() -> void:
+    _handbook_link.bbcode_enabled = true
+    _handbook_link.meta_clicked.connect(_on_meta_clicked)
+    _blueprint_notes.bbcode_enabled = true
+    _blueprint_notes.meta_clicked.connect(_on_meta_clicked)
+    _blueprint_selector.item_selected.connect(_on_blueprint_selected)
+    _preview_button.pressed.connect(_on_preview_pressed)
+    if _hybrid_panel.has_signal("configuration_changed"):
+        _hybrid_panel.configuration_changed.connect(_on_hybrid_configuration_changed)
+    if _template_panel.has_signal("configuration_changed"):
+        _template_panel.configuration_changed.connect(_on_template_configuration_changed)
+    _seed_tree.columns = 3
+    _seed_tree.set_column_title(0, "Node")
+    _seed_tree.set_column_title(1, "Details")
+    _seed_tree.set_column_title(2, "Seed")
+    _seed_tree.set_column_titles_visible(true)
+    _populate_blueprint_selector()
+    if _blueprint_selector.item_count > 0:
+        _blueprint_selector.select(0)
+        _apply_blueprint(String(_blueprint_selector.get_item_metadata(0)))
+
+func set_controller_override(controller: Object) -> void:
+    _controller_override = controller
+    _cached_controller = null
+    if _hybrid_panel.has_method("set_controller_override"):
+        _hybrid_panel.call("set_controller_override", controller)
+    if _template_panel.has_method("set_controller_override"):
+        _template_panel.call("set_controller_override", controller)
+
+func set_metadata_service_override(service: Object) -> void:
+    _metadata_service_override = service
+    _cached_metadata_service = null
+    if _hybrid_panel.has_method("set_metadata_service_override"):
+        _hybrid_panel.call("set_metadata_service_override", service)
+    if _template_panel.has_method("set_metadata_service_override"):
+        _template_panel.call("set_metadata_service_override", service)
+
+func refresh() -> void:
+    if _hybrid_panel.has_method("refresh"):
+        _hybrid_panel.call("refresh")
+    if _template_panel.has_method("refresh"):
+        _template_panel.call("refresh")
+    _rebuild_propagation_tree()
+
+func _populate_blueprint_selector() -> void:
+    _blueprint_lookup.clear()
+    _blueprint_selector.clear()
+    for blueprint in BLUEPRINTS:
+        var id := String(blueprint.get("id", ""))
+        if id == "":
+            continue
+        _blueprint_lookup[id] = blueprint
+        var index := _blueprint_selector.item_count
+        _blueprint_selector.add_item(String(blueprint.get("display_name", id)))
+        _blueprint_selector.set_item_metadata(index, id)
+
+func _on_blueprint_selected(index: int) -> void:
+    var id := String(_blueprint_selector.get_item_metadata(index))
+    _apply_blueprint(id)
+
+func _apply_blueprint(id: String) -> void:
+    if not _blueprint_lookup.has(id):
+        return
+    _current_blueprint_id = id
+    var blueprint: Dictionary = _blueprint_lookup[id]
+    _render_handbook_link(blueprint)
+    _render_blueprint_notes(blueprint)
+    if _hybrid_panel.has_method("apply_config_payload"):
+        _hybrid_panel.call("apply_config_payload", blueprint.get("hybrid", {}))
+    if _template_panel.has_method("apply_config_payload"):
+        _template_panel.call("apply_config_payload", blueprint.get("template", {}))
+    _sync_template_step()
+    _rebuild_propagation_tree()
+    _preview_label.visible = false
+
+func _render_handbook_link(blueprint: Dictionary) -> void:
+    var anchor := String(blueprint.get("handbook_anchor", ""))
+    var link := _build_reference_url(SENTENCE_DOC_PATH, anchor)
+    _handbook_link.bbcode_text = "[url=%s]Open handbook example[/url]" % link
+
+func _render_blueprint_notes(blueprint: Dictionary) -> void:
+    var description := String(blueprint.get("description", ""))
+    var notes_variant := blueprint.get("notes", [])
+    var bullet_lines: Array[String] = []
+    if notes_variant is Array:
+        for entry in notes_variant:
+            bullet_lines.append(String(entry))
+    var anchor := String(blueprint.get("handbook_anchor", ""))
+    var link := _build_reference_url(SENTENCE_DOC_PATH, anchor)
+    var text := "[b]%s[/b]\n[list]" % description
+    for line in bullet_lines:
+        text += "\n[*]" + line
+    text += "\n[*]See [url=%s]devdocs/sentences.md[/url] for the full blueprint." % link
+    text += "\n[/list]"
+    _blueprint_notes.bbcode_text = text
+
+func _sync_template_step() -> void:
+    if not _blueprint_lookup.has(_current_blueprint_id):
+        return
+    var blueprint: Dictionary = _blueprint_lookup[_current_blueprint_id]
+    var alias := String(blueprint.get("template_step_alias", ""))
+    if alias == "":
+        return
+    if not _hybrid_panel.has_method("apply_step_config"):
+        return
+    var config := {} if not _template_panel.has_method("build_config_payload") else _template_panel.call("build_config_payload")
+    if typeof(config) != TYPE_DICTIONARY:
+        return
+    _hybrid_panel.call("apply_step_config", alias, (config as Dictionary))
+
+func _on_hybrid_configuration_changed() -> void:
+    _rebuild_propagation_tree()
+
+func _on_template_configuration_changed() -> void:
+    _sync_template_step()
+
+func _rebuild_propagation_tree() -> void:
+    _seed_tree.clear()
+    var root := _seed_tree.create_item()
+    var pipeline_seed := "" if not _hybrid_panel.has_method("get_pipeline_seed") else String(_hybrid_panel.call("get_pipeline_seed"))
+    var pipeline_item := _seed_tree.create_item(root)
+    pipeline_item.set_text(0, "Pipeline seed")
+    pipeline_item.set_text(1, pipeline_seed if pipeline_seed != "" else "Seed not set")
+    pipeline_item.set_text(2, "hybrid")
+    if pipeline_seed == "":
+        _tint_row(pipeline_item, _ERROR_TINT)
+        pipeline_item.set_tooltip_text(1, "Provide a top-level seed to keep previews deterministic.")
+    var steps_info := []
+    if _hybrid_panel.has_method("describe_seed_propagation"):
+        steps_info = _hybrid_panel.call("describe_seed_propagation")
+    if steps_info is Array:
+        for entry in steps_info:
+            if typeof(entry) != TYPE_DICTIONARY:
+                continue
+            var info: Dictionary = entry
+            var alias := String(info.get("alias", ""))
+            var strategy := String(info.get("strategy", ""))
+            var seed_value := String(info.get("seed", ""))
+            var step_item := _seed_tree.create_item(pipeline_item)
+            step_item.set_text(0, "%s" % strategy.capitalize())
+            step_item.set_text(1, "$%s" % alias)
+            step_item.set_text(2, seed_value)
+            if not bool(info.get("has_alias", true)):
+                _tint_row(step_item, _ERROR_TINT)
+                step_item.set_tooltip_text(1, "Assign a store_as alias so templates can reference this step.")
+            elif pipeline_seed != "":
+                _tint_row(step_item, _INFO_TINT)
+            if strategy == "template":
+                _render_template_structure(step_item, seed_value)
+
+func _render_template_structure(parent: TreeItem, inherited_seed: String) -> void:
+    if not _template_panel.has_method("evaluate_configuration"):
+        return
+    var evaluation := _template_panel.call("evaluate_configuration", inherited_seed)
+    if typeof(evaluation) != TYPE_DICTIONARY:
+        return
+    var payload: Dictionary = evaluation
+    var structure := payload.get("structure", {})
+    if typeof(structure) != TYPE_DICTIONARY:
+        return
+    var template_item := _seed_tree.create_item(parent)
+    template_item.set_text(0, "Template root")
+    template_item.set_text(1, String(structure.get("template", "")))
+    template_item.set_text(2, String(structure.get("seed", inherited_seed)))
+    var errors := payload.get("errors", [])
+    if errors is Array and not errors.is_empty():
+        _tint_row(template_item, _ERROR_TINT)
+        template_item.set_tooltip_text(1, "Template contains validation errors.")
+    _render_template_children(template_item, structure.get("children", []))
+
+func _render_template_children(parent: TreeItem, children: Array) -> void:
+    for child_variant in children:
+        if typeof(child_variant) != TYPE_DICTIONARY:
+            continue
+        var child: Dictionary = child_variant
+        var node_type := String(child.get("node_type", ""))
+        var item := _seed_tree.create_item(parent)
+        if node_type == "token":
+            item.set_text(0, "[%s]" % String(child.get("token", "")))
+            item.set_text(1, String(child.get("display_name", child.get("strategy", ""))))
+            item.set_text(2, String(child.get("seed", "")))
+            if (child.get("errors", []) is Array) and not (child.get("errors", []) as Array).is_empty():
+                _tint_row(item, _ERROR_TINT)
+            _render_template_children(item, child.get("children", []))
+        else:
+            item.set_text(0, node_type.capitalize())
+            item.set_text(1, String(child.get("template", "")))
+            item.set_text(2, String(child.get("seed", "")))
+            _render_template_children(item, child.get("children", []))
+
+func _preview_button_label(status: String) -> Color:
+    return Color(0.85, 1.0, 0.85, 1.0) if status == "success" else Color(1.0, 0.85, 0.85, 1.0)
+
+func _on_preview_pressed() -> void:
+    var controller := _get_controller()
+    if controller == null:
+        _show_preview_state({
+            "status": "error",
+            "message": "RNGProcessor controller unavailable.",
+        })
+        return
+    if not _hybrid_panel.has_method("build_config_payload"):
+        _show_preview_state({"status": "error", "message": "Hybrid panel unavailable."})
+        return
+    var payload_variant := _hybrid_panel.call("build_config_payload")
+    if typeof(payload_variant) != TYPE_DICTIONARY:
+        _show_preview_state({"status": "error", "message": "Failed to build hybrid payload."})
+        return
+    var payload: Dictionary = payload_variant
+    var steps := payload.get("steps", [])
+    if steps is Array and steps.is_empty():
+        _show_preview_state({"status": "error", "message": "Configure at least one hybrid step."})
+        return
+    _inject_template_payload(steps)
+    payload["steps"] = steps
+    var response: Variant = controller.call("generate", payload)
+    if response is Dictionary and response.has("code"):
+        var error_dict: Dictionary = response
+        _show_preview_state({
+            "status": "error",
+            "message": String(error_dict.get("message", "Generation failed.")),
+        })
+        return
+    _show_preview_state({"status": "success", "message": String(response)})
+    _rebuild_propagation_tree()
+
+func _inject_template_payload(steps: Array) -> void:
+    if not _blueprint_lookup.has(_current_blueprint_id):
+        return
+    var alias := String(_blueprint_lookup[_current_blueprint_id].get("template_step_alias", ""))
+    if alias == "":
+        return
+    if not _template_panel.has_method("build_config_payload"):
+        return
+    var template_variant := _template_panel.call("build_config_payload")
+    if typeof(template_variant) != TYPE_DICTIONARY:
+        return
+    var template_config: Dictionary = template_variant
+    for index in range(steps.size()):
+        var entry_variant := steps[index]
+        if typeof(entry_variant) != TYPE_DICTIONARY:
+            continue
+        var entry: Dictionary = entry_variant
+        var entry_alias := String(entry.get("store_as", ""))
+        var config_variant := entry.get("config", {})
+        if alias != "" and entry_alias == alias:
+            entry["config"] = template_config.duplicate(true)
+            steps[index] = entry
+            return
+        if alias == "" and typeof(config_variant) == TYPE_DICTIONARY and String(config_variant.get("strategy", "")) == "template":
+            entry["config"] = template_config.duplicate(true)
+            steps[index] = entry
+            return
+
+func _show_preview_state(state: Dictionary) -> void:
+    var status := String(state.get("status", ""))
+    var message := String(state.get("message", ""))
+    _preview_label.visible = true
+    _preview_label.text = message
+    _preview_label.self_modulate = _preview_button_label(status)
+
+func _on_meta_clicked(meta: Variant) -> void:
+    var target := String(meta)
+    if target.begins_with("res://"):
+        target = ProjectSettings.globalize_path(target)
+    if target == "":
+        return
+    OS.shell_open(target)
+
+func _tint_row(item: TreeItem, tint: Color) -> void:
+    for column in range(_seed_tree.columns):
+        item.set_custom_bg_color(column, tint)
+
+func _build_reference_url(path: String, anchor: String) -> String:
+    if anchor == "":
+        return path
+    if path.find("#") != -1:
+        return path
+    return "%s#%s" % [path, anchor]
+
+func _get_controller() -> Object:
+    if _controller_override != null and _is_object_valid(_controller_override):
+        return _controller_override
+    if _cached_controller != null and _is_object_valid(_cached_controller):
+        return _cached_controller
+    if controller_path != NodePath("") and has_node(controller_path):
+        var node := get_node(controller_path)
+        if node != null:
+            _cached_controller = node
+            return _cached_controller
+    if Engine.has_singleton("RNGProcessorController"):
+        var singleton := Engine.get_singleton("RNGProcessorController")
+        if _is_object_valid(singleton):
+            _cached_controller = singleton
+            return _cached_controller
+    return null
+
+func _is_object_valid(candidate: Object) -> bool:
+    if candidate == null:
+        return false
+    if candidate is Node:
+        return is_instance_valid(candidate)
+    return true

--- a/addons/platform_gui/workspaces/formulas/FormulasWorkspace.tscn
+++ b/addons/platform_gui/workspaces/formulas/FormulasWorkspace.tscn
@@ -1,0 +1,129 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://addons/platform_gui/workspaces/formulas/FormulasWorkspace.gd" id="1_vnru3"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/hybrid/HybridPipelinePanel.tscn" id="2_ny06x"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/template/TemplatePanel.tscn" id="3_rxymd"]
+
+[node name="FormulasWorkspace" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_vnru3")
+
+[node name="Main" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Header" type="HBoxContainer" parent="Main"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Title" type="Label" parent="Main/Header"]
+layout_mode = 2
+text = "Formulas"
+size_flags_horizontal = 1
+
+[node name="BlueprintSelector" type="OptionButton" parent="Main/Header"]
+layout_mode = 2
+size_flags_horizontal = 3
+focus_mode = 1
+
+[node name="HandbookLink" type="RichTextLabel" parent="Main"]
+layout_mode = 2
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 24)
+autowrap_mode = 3
+
+[node name="BlueprintNotes" type="RichTextLabel" parent="Main"]
+layout_mode = 2
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 64)
+autowrap_mode = 3
+
+[node name="PropagationPanel" type="PanelContainer" parent="Main"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 200)
+
+[node name="PropagationVBox" type="VBoxContainer" parent="Main/PropagationPanel"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="PropagationTitle" type="Label" parent="Main/PropagationPanel/PropagationVBox"]
+layout_mode = 2
+text = "Seed & Alias Propagation"
+
+[node name="PropagationTree" type="Tree" parent="Main/PropagationPanel/PropagationVBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+columns = 3
+allow_reselect = true
+hide_root = false
+
+[node name="EditorSplit" type="HSplitContainer" parent="Main"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 240)
+
+[node name="HybridColumn" type="VBoxContainer" parent="Main/EditorSplit"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HybridLabel" type="Label" parent="Main/EditorSplit/HybridColumn"]
+layout_mode = 2
+text = "Hybrid pipeline"
+
+[node name="HybridPanelContainer" type="PanelContainer" parent="Main/EditorSplit/HybridColumn"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HybridPanel" parent="Main/EditorSplit/HybridColumn/HybridPanelContainer" instance=ExtResource("2_ny06x")]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="TemplateColumn" type="VBoxContainer" parent="Main/EditorSplit"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="TemplateLabel" type="Label" parent="Main/EditorSplit/TemplateColumn"]
+layout_mode = 2
+text = "Template node"
+
+[node name="TemplatePanelContainer" type="PanelContainer" parent="Main/EditorSplit/TemplateColumn"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="TemplatePanel" parent="Main/EditorSplit/TemplateColumn/TemplatePanelContainer" instance=ExtResource("3_rxymd")]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="PreviewRow" type="HBoxContainer" parent="Main"]
+layout_mode = 2
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 40)
+
+[node name="PreviewButton" type="Button" parent="Main/PreviewRow"]
+layout_mode = 2
+size_flags_horizontal = 1
+text = "Preview formula"
+
+[node name="PreviewLabel" type="RichTextLabel" parent="Main/PreviewRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+autowrap_mode = 3
+visible = false
+custom_minimum_size = Vector2(0, 40)
+

--- a/data/wordlists/factions/faction_titles.tres
+++ b/data/wordlists/factions/faction_titles.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("Skyward Accord", "Iron Sigil", "Verdant Shroud", "Obsidian Reliquary", "Aurora Choir")
+weighted_entries = []

--- a/data/wordlists/factions/mission_targets.tres
+++ b/data/wordlists/factions/mission_targets.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("the ember vault", "the skylance array", "bordering wards", "the oracle nexus", "the crystalline forge")
+weighted_entries = []

--- a/data/wordlists/factions/mission_twists.tres
+++ b/data/wordlists/factions/mission_twists.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray(
+    "before dawn breaks",
+    "without alarming the council",
+    "while the stormbound chant",
+    "beneath rival sight",
+    "without shattering the accord"
+)
+weighted_entries = []

--- a/data/wordlists/factions/mission_verbs.tres
+++ b/data/wordlists/factions/mission_verbs.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("secure", "unravel", "stabilise", "recover", "shield")
+weighted_entries = []

--- a/data/wordlists/skills/skill_payloads.tres
+++ b/data/wordlists/skills/skill_payloads.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("to mend allies", "to unravel wards", "to blind foes", "to steady ranks", "to ignite resolve")
+weighted_entries = []

--- a/data/wordlists/skills/skill_themes.tres
+++ b/data/wordlists/skills/skill_themes.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("storms", "sigils", "embers", "veils", "runes")
+weighted_entries = []

--- a/data/wordlists/skills/skill_verbs.tres
+++ b/data/wordlists/skills/skill_verbs.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("amplify", "channel", "invoke", "shape", "weave")
+weighted_entries = []

--- a/devdocs/platform_gui_handbook.md
+++ b/devdocs/platform_gui_handbook.md
@@ -68,6 +68,14 @@ Follow these steps whenever you need to work inside the Platform GUI:
 7. Review the **Token expansion preview** tree. Each row lists the recursion depth, resolved strategy display name, and the seed that TemplateStrategy will pass to the child generator. Nested template configs expand inline so you can verify cascaded definitions without leaving the panel.
 8. Press **Preview** to request a deterministic sample. Middleware validation errors reuse the metadata service's guidance (for example, empty tokens or missing strategy keys) so the fix is always spelled out next to the relevant control.
 
+### Crafting sentence formulas
+
+1. Open the **Formulas** workspace (`res://addons/platform_gui/workspaces/formulas/FormulasWorkspace.tscn`). The top banner links to the matching anchor inside [`devdocs/sentences.md`](./sentences.md) so you can cross-reference the original blueprint while you work.
+2. Choose a blueprint from the selector. Each option pre-loads the HybridStrategy steps and the nested TemplateStrategy used in the handbook example. The inline notes recap which datasets are involved and why the seeds use specific prefixes.
+3. Review the **Seed & Alias Propagation** panel. Rows tinted blue confirm that aliases inherit the pipeline seed (for example, `skill_sentence_v1::step_skill_verb`), while red rows highlight missing aliases or seeds that need attention before previews stay deterministic.
+4. Edit the template node in the right column. Any changes automatically sync into the matching hybrid step so the in-panel template editor and the standalone template workspace always reflect the same configuration.
+5. Press **Preview formula** to run the combined payload through the middleware. Successful runs return a single deterministic sentence, and the seed tree updates with the latest inheritance trail so you can export the configuration knowing exactly which RNG streams were used.
+
 ### Reviewing DebugRNG logs
 
 1. Switch to the **Debug Logs** tab. When DebugRNG is active, the middleware writes to `user://debug_rng_report.txt` (or a custom path you configured earlier).

--- a/devdocs/sentences.md
+++ b/devdocs/sentences.md
@@ -7,6 +7,8 @@ Designing sentence generators in RNGEN hinges on two composable strategies:
 
 Used together, they let you build deterministic narrative blurbs that weave in multiple datasets.
 
+> **Workspace shortcut** – The Formulas workspace scene (`res://addons/platform_gui/workspaces/formulas/FormulasWorkspace.tscn`) ships with guided blueprints for the examples below. Each blueprint preloads the same hybrid steps, nested templates, and dataset paths documented here so artists can experiment without rebuilding the configuration from scratch.
+
 ## Token naming conventions
 
 Template tokens are wrapped in square brackets. Each token must have an entry with the same name in the `sub_generators` dictionary. Adopt `snake_case` identifiers (e.g. `[skill_summary]`, `[faction_codename]`) so they align with configuration keys and data asset filenames.

--- a/tests/gui/test_formulas_workspace.gd
+++ b/tests/gui/test_formulas_workspace.gd
@@ -1,0 +1,129 @@
+extends RefCounted
+
+const WORKSPACE_SCENE := preload("res://addons/platform_gui/workspaces/formulas/FormulasWorkspace.tscn")
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _reset()
+    _run_test("loads_blueprint_and_panels", func(): _test_loads_blueprint_and_panels())
+    _run_test("renders_seed_propagation", func(): _test_renders_seed_propagation())
+    _run_test("injects_template_during_preview", func(): _test_injects_template_during_preview())
+    return {
+        "suite": "Formulas Workspace",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+    else:
+        _failed += 1
+        _failures.append({"name": name, "message": String(message)})
+
+func _test_loads_blueprint_and_panels() -> Variant:
+    var context := _make_workspace()
+    var workspace := context["workspace"]
+    workspace._ready()
+    workspace.set_controller_override(context["controller"])
+    var hybrid_panel: VBoxContainer = workspace.get_node("Main/EditorSplit/HybridColumn/HybridPanelContainer/HybridPanel")
+    var template_panel: VBoxContainer = workspace.get_node("Main/EditorSplit/TemplateColumn/TemplatePanelContainer/TemplatePanel")
+    var hybrid_payload := hybrid_panel.build_config_payload()
+    if hybrid_payload.get("steps", []).size() == 0:
+        return "Hybrid panel should load blueprint steps during _ready." 
+    var template_payload := template_panel.build_config_payload()
+    if template_payload.get("template_string", "") == "":
+        return "Template panel should preload the blueprint template string."
+    workspace.free()
+    (context["controller"] as ControllerStub).free()
+    return null
+
+func _test_renders_seed_propagation() -> Variant:
+    var context := _make_workspace()
+    var workspace := context["workspace"]
+    workspace._ready()
+    workspace.set_controller_override(context["controller"])
+    var tree: Tree = workspace.get_node("Main/PropagationPanel/PropagationVBox/PropagationTree")
+    var root := tree.get_root()
+    if root == null:
+        return "Propagation tree should create a root item."
+    var pipeline_item := root.get_first_child()
+    if pipeline_item == null:
+        return "Propagation tree should include pipeline seed row."
+    var step_item := pipeline_item.get_first_child()
+    if step_item == null:
+        return "Propagation tree should list hybrid steps."
+    if not step_item.get_text(1).begins_with("$"):
+        return "Hybrid step rows should surface alias placeholders."
+    workspace.free()
+    (context["controller"] as ControllerStub).free()
+    return null
+
+func _test_injects_template_during_preview() -> Variant:
+    var context := _make_workspace()
+    var workspace := context["workspace"]
+    workspace._ready()
+    var controller := context["controller"] as ControllerStub
+    workspace.set_controller_override(controller)
+    var template_panel: VBoxContainer = workspace.get_node("Main/EditorSplit/TemplateColumn/TemplatePanelContainer/TemplatePanel")
+    var custom_template := {
+        "strategy": "template",
+        "template_string": "[custom_node]",
+        "sub_generators": {
+            "custom_node": {
+                "strategy": "wordlist",
+                "wordlist_paths": ["res://data/wordlists/skills/skill_verbs.tres"],
+            },
+        },
+    }
+    template_panel.apply_config_payload(custom_template)
+    workspace._on_preview_pressed()
+    var payload: Dictionary = controller.last_config
+    if payload.get("strategy", "") != "hybrid":
+        return "Preview should build a hybrid strategy payload."
+    var steps: Array = payload.get("steps", [])
+    if steps.is_empty():
+        return "Preview payload should include hybrid steps."
+    var template_found := false
+    for entry_variant in steps:
+        if typeof(entry_variant) != TYPE_DICTIONARY:
+            continue
+        var entry: Dictionary = entry_variant
+        if String(entry.get("store_as", "")) == "skill_sentence" or String(entry.get("store_as", "")) == "mission_body":
+            var config := entry.get("config", {})
+            if typeof(config) == TYPE_DICTIONARY and String(config.get("template_string", "")) == "[custom_node]":
+                template_found = true
+    if not template_found:
+        return "Preview should inject the edited template configuration into the matching step."
+    workspace.free()
+    controller.free()
+    return null
+
+func _make_workspace() -> Dictionary:
+    var workspace := WORKSPACE_SCENE.instantiate()
+    var controller := ControllerStub.new()
+    return {"workspace": workspace, "controller": controller}
+
+func _reset() -> void:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+class ControllerStub:
+    extends Node
+
+    var last_config: Dictionary = {}
+    var response: Variant = "Preview sample"
+
+    func generate(config: Dictionary) -> Variant:
+        last_config = config.duplicate(true)
+        return response

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -41,6 +41,10 @@
       "path": "res://tests/gui/test_hybrid_pipeline_panel.gd"
     },
     {
+      "name": "Formulas Workspace Suite",
+      "path": "res://tests/gui/test_formulas_workspace.gd"
+    },
+    {
       "name": "Name Generator Diagnostic",
       "path": "res://tests/diagnostics/name_generator_diagnostic.gd",
       "id": "name_generator"


### PR DESCRIPTION
## Summary
- add a Formulas workspace scene that loads handbook blueprints, synchronises hybrid/template configs, and previews combined output
- extend hybrid, template, and wordlist panels with configuration import helpers plus propagation signals for workspace tooling
- bundle skill and faction word lists, document the workflow, and add a focused GUI test suite

## Testing
- ⚠️ `godot --headless --script res://tests/run_all_tests.gd` *(command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8070be10832085ae4688eed313e7