### PR TITLE
Add DebugRNG toolbar and log viewer

### DIFF
--- a/addons/platform_gui/components/DebugToolbar.gd
+++ b/addons/platform_gui/components/DebugToolbar.gd
@@ -1,0 +1,147 @@
+extends HBoxContainer
+
+## Toolbar controls that manage DebugRNG sessions for the Platform GUI.
+##
+## The toolbar acts as a light-weight front-end to the RNGProcessor
+## controller, allowing artists and support engineers to capture session
+## metadata, start/stop DebugRNG logging, and toggle helper attachment
+## without touching the middleware singletons directly. All controller
+## lookups are cached so the component can run in isolation during tests.
+
+@export var controller_path: NodePath
+
+const DebugRNG := preload("res://name_generator/tools/DebugRNG.gd")
+
+const _INFO_COLOR := Color(0.3, 0.6, 0.9)
+const _ERROR_COLOR := Color(0.86, 0.23, 0.23)
+
+@onready var _session_label_edit: LineEdit = %SessionLabel
+@onready var _ticket_edit: LineEdit = %TicketInput
+@onready var _notes_edit: LineEdit = %NotesInput
+@onready var _start_button: Button = %StartSessionButton
+@onready var _attach_button: Button = %AttachButton
+@onready var _detach_button: Button = %DetachButton
+@onready var _stop_button: Button = %StopSessionButton
+@onready var _status_label: RichTextLabel = %StatusLabel
+
+var _controller_override: Object = null
+var _cached_controller: Object = null
+var _debug_rng: DebugRNG = null
+
+func _ready() -> void:
+    _status_label.bbcode_enabled = true
+    _start_button.pressed.connect(_on_start_pressed)
+    _attach_button.pressed.connect(_on_attach_pressed)
+    _detach_button.pressed.connect(_on_detach_pressed)
+    _stop_button.pressed.connect(_on_stop_pressed)
+    _update_button_states()
+
+func set_controller_override(controller: Object) -> void:
+    ## Inject a deterministic controller override for tests and tooling.
+    _controller_override = controller
+    _cached_controller = null
+    _update_button_states()
+
+func clear_controller_override() -> void:
+    ## Clear the controller override and fall back to exported lookups.
+    _controller_override = null
+    _cached_controller = null
+    _update_button_states()
+
+func get_active_debug_rng() -> DebugRNG:
+    ## Return the DebugRNG instance managed by the toolbar, if any.
+    return _debug_rng
+
+func refresh() -> void:
+    ## External hook to refresh controller lookups and button states.
+    _cached_controller = null
+    _update_button_states()
+
+func _on_start_pressed() -> void:
+    _start_new_session()
+    _update_button_states()
+
+func _on_attach_pressed() -> void:
+    if _debug_rng == null:
+        _set_status(_format_error("Start a DebugRNG session before attaching."))
+        return
+    var controller := _get_controller()
+    if controller == null or not controller.has_method("set_debug_rng"):
+        _set_status(_format_error("RNGProcessor controller unavailable; attach skipped."))
+        return
+    controller.call("set_debug_rng", _debug_rng, true)
+    _set_status("Attached DebugRNG helper to middleware.")
+
+func _on_detach_pressed() -> void:
+    var detached := _detach_helper()
+    if detached:
+        _set_status("Detached DebugRNG helper.")
+    _update_button_states()
+
+func _on_stop_pressed() -> void:
+    _detach_helper(false)
+    if _debug_rng != null:
+        _debug_rng.close()
+        _debug_rng = null
+    _set_status("DebugRNG session closed.")
+    _update_button_states()
+
+func _start_new_session() -> void:
+    if _debug_rng != null:
+        _debug_rng.close()
+    _debug_rng = DebugRNG.new()
+    var metadata := _collect_metadata()
+    if _debug_rng.has_method("begin_session"):
+        _debug_rng.begin_session(metadata)
+    _set_status("DebugRNG session started.")
+
+func _collect_metadata() -> Dictionary:
+    var metadata := {}
+    var label := _session_label_edit.text.strip_edges()
+    if label != "":
+        metadata["label"] = label
+    var ticket := _ticket_edit.text.strip_edges()
+    if ticket != "":
+        metadata["ticket"] = ticket
+    var notes := _notes_edit.text.strip_edges()
+    if notes != "":
+        metadata["notes"] = notes
+    return metadata
+
+func _detach_helper(update_status: bool = true) -> bool:
+    var controller := _get_controller()
+    if controller == null or not controller.has_method("set_debug_rng"):
+        if update_status:
+            _set_status(_format_error("RNGProcessor controller unavailable; detach skipped."))
+        return false
+    controller.call("set_debug_rng", null)
+    return true
+
+func _update_button_states() -> void:
+    var has_debug := _debug_rng != null
+    _attach_button.disabled = not has_debug or _get_controller() == null
+    _detach_button.disabled = _get_controller() == null
+    _stop_button.disabled = not has_debug
+
+func _set_status(message: String) -> void:
+    _status_label.text = message
+
+func _format_error(message: String) -> String:
+    return "[color=%s]%s[/color]" % [_ERROR_COLOR.to_html(), message]
+
+func _get_controller() -> Object:
+    if _controller_override != null:
+        return _controller_override
+    if _cached_controller != null and is_instance_valid(_cached_controller):
+        return _cached_controller
+    if controller_path != NodePath("") and has_node(controller_path):
+        var node := get_node(controller_path)
+        if node != null:
+            _cached_controller = node
+            return _cached_controller
+    if Engine.has_singleton("RNGProcessorController"):
+        var singleton := Engine.get_singleton("RNGProcessorController")
+        if singleton != null:
+            _cached_controller = singleton
+            return _cached_controller
+    return null

--- a/addons/platform_gui/components/DebugToolbar.tscn
+++ b/addons/platform_gui/components/DebugToolbar.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://addons/platform_gui/components/DebugToolbar.gd" id="1_hm1m4"]
+
+[node name="DebugToolbar" type="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+script = ExtResource("1_hm1m4")
+
+[node name="SessionLabelTitle" type="Label" parent="."]
+layout_mode = 2
+text = "Session label"
+
+[node name="SessionLabel" type="LineEdit" parent="."]
+layout_mode = 2
+size_flags_horizontal = 1
+custom_minimum_size = Vector2(120, 0)
+
+[node name="TicketTitle" type="Label" parent="."]
+layout_mode = 2
+text = "Ticket"
+
+[node name="TicketInput" type="LineEdit" parent="."]
+layout_mode = 2
+size_flags_horizontal = 1
+custom_minimum_size = Vector2(120, 0)
+
+[node name="NotesTitle" type="Label" parent="."]
+layout_mode = 2
+text = "Notes"
+
+[node name="NotesInput" type="LineEdit" parent="."]
+layout_mode = 2
+size_flags_horizontal = 1
+custom_minimum_size = Vector2(160, 0)
+
+[node name="StartSessionButton" type="Button" parent="."]
+layout_mode = 2
+text = "Start session"
+
+[node name="AttachButton" type="Button" parent="."]
+layout_mode = 2
+text = "Attach"
+
+[node name="DetachButton" type="Button" parent="."]
+layout_mode = 2
+text = "Detach"
+
+[node name="StopSessionButton" type="Button" parent="."]
+layout_mode = 2
+text = "Stop"
+
+[node name="StatusLabel" type="RichTextLabel" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(240, 32)
+bbcode_enabled = true
+scroll_active = false
+scroll_following = true

--- a/addons/platform_gui/panels/logs/DebugLogPanel.gd
+++ b/addons/platform_gui/panels/logs/DebugLogPanel.gd
@@ -1,0 +1,289 @@
+extends VBoxContainer
+
+## Panel that visualises DebugRNG telemetry captured by the RNGProcessor.
+##
+## The panel reads structured telemetry from the active DebugRNG helper,
+## renders section-specific summaries (timeline, warnings, stream usage,
+## strategy errors), and offers an inline download helper so engineers can
+## archive the raw TXT report without leaving the editor.
+
+@export var controller_path: NodePath
+
+const DebugRNG := preload("res://name_generator/tools/DebugRNG.gd")
+
+const SECTION_ALL := 0
+const SECTION_TIMELINE := 1
+const SECTION_WARNINGS := 2
+const SECTION_STREAMS := 3
+const SECTION_STRATEGY_ERRORS := 4
+
+const _INFO_COLOR := Color(0.3, 0.6, 0.9)
+const _ERROR_COLOR := Color(0.86, 0.23, 0.23)
+const _WARNING_COLOR := Color(0.82, 0.49, 0.09)
+
+@onready var _refresh_button: Button = %RefreshButton
+@onready var _section_selector: OptionButton = %SectionSelector
+@onready var _log_display: RichTextLabel = %LogDisplay
+@onready var _download_path: LineEdit = %DownloadPath
+@onready var _download_button: Button = %DownloadButton
+@onready var _status_label: RichTextLabel = %StatusLabel
+
+var _controller_override: Object = null
+var _cached_controller: Object = null
+var _report_cache: Dictionary = {}
+
+func _ready() -> void:
+    _log_display.bbcode_enabled = true
+    _status_label.bbcode_enabled = true
+    _refresh_button.pressed.connect(_on_refresh_pressed)
+    _download_button.pressed.connect(_on_download_pressed)
+    _section_selector.item_selected.connect(_on_section_selected)
+    _populate_sections()
+    _update_display()
+
+func set_controller_override(controller: Object) -> void:
+    _controller_override = controller
+    _cached_controller = null
+    _update_button_states()
+
+func clear_controller_override() -> void:
+    _controller_override = null
+    _cached_controller = null
+    _update_button_states()
+
+func refresh() -> void:
+    _load_report()
+
+func _populate_sections() -> void:
+    _section_selector.clear()
+    _section_selector.add_item("All sections", SECTION_ALL)
+    _section_selector.add_item("Generation timeline", SECTION_TIMELINE)
+    _section_selector.add_item("Warnings", SECTION_WARNINGS)
+    _section_selector.add_item("Stream usage", SECTION_STREAMS)
+    _section_selector.add_item("Strategy errors", SECTION_STRATEGY_ERRORS)
+    _section_selector.selected = SECTION_ALL
+
+func _on_refresh_pressed() -> void:
+    _load_report()
+
+func _on_download_pressed() -> void:
+    if _report_cache.is_empty():
+        _set_status(_format_error("Attach DebugRNG before downloading."))
+        return
+    var source_path := String(_report_cache.get("log_path", ""))
+    if source_path == "":
+        _set_status(_format_error("DebugRNG did not report a log path."))
+        return
+    if not FileAccess.file_exists(source_path):
+        _set_status(_format_error("DebugRNG log not found at %s." % source_path))
+        return
+    var target_path := _download_path.text.strip_edges()
+    if target_path == "":
+        _set_status(_format_error("Provide a download path (e.g. user://debug_rng_copy.txt)."))
+        return
+    var content := FileAccess.get_file_as_string(source_path)
+    var file := FileAccess.open(target_path, FileAccess.WRITE)
+    if file == null:
+        _set_status(_format_error("Unable to open %s for writing." % target_path))
+        return
+    file.store_string(content)
+    _set_status("Saved DebugRNG report to %s." % target_path)
+
+func _on_section_selected(index: int) -> void:
+    _section_selector.selected = index
+    _update_display()
+
+func _load_report() -> void:
+    var controller := _get_controller()
+    if controller == null or not controller.has_method("get_debug_rng"):
+        _report_cache = {}
+        _set_status(_format_error("RNGProcessor controller unavailable."))
+        _update_display()
+        return
+
+    var debug_rng: Object = controller.call("get_debug_rng")
+    if debug_rng == null:
+        _report_cache = {}
+        _set_status(_format_error("DebugRNG helper is not attached."))
+        _update_display()
+        return
+    if not debug_rng is DebugRNG and not debug_rng.has_method("read_current_log"):
+        _report_cache = {}
+        _set_status(_format_error("Attached helper does not expose read_current_log()."))
+        _update_display()
+        return
+
+    var payload: Variant = debug_rng.call("read_current_log")
+    if payload is Dictionary:
+        _report_cache = (payload as Dictionary).duplicate(true)
+        _set_status("Loaded DebugRNG report with %d entries." % _report_cache.get("entries", []).size())
+    else:
+        _report_cache = {}
+        _set_status(_format_error("DebugRNG returned unexpected telemetry payload."))
+    _update_display()
+
+func _update_display() -> void:
+    var lines := PackedStringArray()
+    if _report_cache.is_empty():
+        lines.append("DebugRNG helper inactive.")
+        _log_display.bbcode_text = "\n".join(lines)
+        _update_button_states()
+        return
+
+    lines.append_array(_render_session_header())
+    lines.append("")
+    lines.append_array(_render_section_entries(_section_selector.selected))
+    _log_display.bbcode_text = "\n".join(lines)
+    _update_button_states()
+
+func _render_session_header() -> PackedStringArray:
+    var lines := PackedStringArray()
+    var started := String(_report_cache.get("session_started_at", "--"))
+    var ended := String(_report_cache.get("session_ended_at", "--"))
+    var active := bool(_report_cache.get("session_open", false))
+    lines.append("[b]Session started:[/b] %s" % started)
+    lines.append("[b]Session ended:[/b] %s" % (active ? "(active)" : ended))
+
+    var metadata_variant := _report_cache.get("metadata", {})
+    if metadata_variant is Dictionary and not (metadata_variant as Dictionary).is_empty():
+        var metadata: Dictionary = metadata_variant
+        var keys := metadata.keys()
+        keys.sort_custom(func(a, b): return String(a) < String(b))
+        lines.append("[b]Metadata[/b]")
+        for key in keys:
+            lines.append("• %s: %s" % [String(key), _stringify_value(metadata[key])])
+
+    var stats_variant := _report_cache.get("stats", {})
+    if stats_variant is Dictionary and not (stats_variant as Dictionary).is_empty():
+        var stats: Dictionary = stats_variant
+        lines.append("[b]Aggregate statistics[/b]")
+        var stat_keys := stats.keys()
+        stat_keys.sort_custom(func(a, b): return String(a) < String(b))
+        for key in stat_keys:
+            lines.append("• %s: %s" % [String(key), _stringify_value(stats[key])])
+
+    return lines
+
+func _render_section_entries(section: int) -> PackedStringArray:
+    var lines := PackedStringArray()
+    var entries_variant := _report_cache.get("entries", [])
+    if not (entries_variant is Array):
+        lines.append("No telemetry entries available.")
+        return lines
+
+    var entries: Array = entries_variant
+    var count := 0
+    for entry_variant in entries:
+        if typeof(entry_variant) != TYPE_DICTIONARY:
+            continue
+        var entry: Dictionary = entry_variant
+        if not _entry_matches_section(entry, section):
+            continue
+        lines.append(_format_entry(entry))
+        count += 1
+
+    if count == 0:
+        match section:
+            SECTION_WARNINGS:
+                lines.append("No warnings recorded.")
+            SECTION_STREAMS:
+                lines.append("No stream usage recorded.")
+            SECTION_STRATEGY_ERRORS:
+                lines.append("No strategy errors recorded.")
+            SECTION_TIMELINE:
+                lines.append("No generation activity recorded.")
+            _:
+                lines.append("No telemetry entries available.")
+
+    return lines
+
+func _entry_matches_section(entry: Dictionary, section: int) -> bool:
+    var type_name := String(entry.get("type", ""))
+    match section:
+        SECTION_WARNINGS:
+            return type_name == "warning"
+        SECTION_STREAMS:
+            return type_name == "stream_usage"
+        SECTION_STRATEGY_ERRORS:
+            return type_name == "strategy_error"
+        SECTION_TIMELINE:
+            return type_name in ["generation_started", "generation_completed", "generation_failed", "strategy_error"]
+        _:
+            return true
+
+func _format_entry(entry: Dictionary) -> String:
+    var type_name := String(entry.get("type", ""))
+    var timestamp := String(entry.get("timestamp", ""))
+    match type_name:
+        "warning":
+            return "[color=%s]⚠️ %s %s[/color]" % [_WARNING_COLOR.to_html(), timestamp, _stringify_value(entry.get("message", ""))]
+        "strategy_error":
+            return "[color=%s]‼ %s strategy=%s code=%s message=%s[/color]" % [
+                _ERROR_COLOR.to_html(),
+                timestamp,
+                String(entry.get("strategy_id", "")),
+                String(entry.get("code", "")),
+                _stringify_value(entry.get("message", "")),
+            ]
+        "stream_usage":
+            return "%s stream=%s context=%s" % [
+                timestamp,
+                String(entry.get("stream", "")),
+                _stringify_value(entry.get("context", {})),
+            ]
+        "generation_started":
+            return "[b]%s[/b] START strategy=%s seed=%s stream=%s" % [
+                timestamp,
+                entry.get("metadata", {}).get("strategy_id", ""),
+                entry.get("metadata", {}).get("seed", ""),
+                entry.get("metadata", {}).get("rng_stream", ""),
+            ]
+        "generation_completed":
+            return "%s COMPLETE strategy=%s result=%s" % [
+                timestamp,
+                entry.get("metadata", {}).get("strategy_id", ""),
+                _stringify_value(entry.get("result", "")),
+            ]
+        "generation_failed":
+            return "[color=%s]%s FAIL strategy=%s code=%s details=%s[/color]" % [
+                _ERROR_COLOR.to_html(),
+                timestamp,
+                entry.get("metadata", {}).get("strategy_id", ""),
+                entry.get("error", {}).get("code", ""),
+                _stringify_value(entry.get("error", {})),
+            ]
+        _:
+            return "%s %s" % [timestamp, _stringify_value(entry)]
+
+func _update_button_states() -> void:
+    var has_report := not _report_cache.is_empty()
+    _download_button.disabled = not has_report
+
+func _set_status(message: String) -> void:
+    _status_label.text = message if message.begins_with("[color=") else "[color=%s]%s[/color]" % [_INFO_COLOR.to_html(), message]
+
+func _format_error(message: String) -> String:
+    return "[color=%s]%s[/color]" % [_ERROR_COLOR.to_html(), message]
+
+func _stringify_value(value: Variant) -> String:
+    if value is String:
+        return value
+    var json := JSON.new()
+    return json.stringify(value)
+
+func _get_controller() -> Object:
+    if _controller_override != null:
+        return _controller_override
+    if _cached_controller != null and is_instance_valid(_cached_controller):
+        return _cached_controller
+    if controller_path != NodePath("") and has_node(controller_path):
+        var node := get_node(controller_path)
+        if node != null:
+            _cached_controller = node
+            return _cached_controller
+    if Engine.has_singleton("RNGProcessorController"):
+        var singleton := Engine.get_singleton("RNGProcessorController")
+        if singleton != null:
+            _cached_controller = singleton
+            return _cached_controller
+    return null

--- a/addons/platform_gui/panels/logs/DebugLogPanel.tscn
+++ b/addons/platform_gui/panels/logs/DebugLogPanel.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://addons/platform_gui/panels/logs/DebugLogPanel.gd" id="1_r9a7o"]
+
+[node name="DebugLogPanel" type="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_r9a7o")
+
+[node name="Header" type="HBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="RefreshButton" type="Button" parent="Header"]
+layout_mode = 2
+text = "Refresh log"
+
+[node name="SectionSelector" type="OptionButton" parent="Header"]
+layout_mode = 2
+size_flags_horizontal = 1
+
+[node name="DownloadPath" type="LineEdit" parent="Header"]
+layout_mode = 2
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(240, 0)
+placeholder_text = "user://debug_rng_copy.txt"
+
+[node name="DownloadButton" type="Button" parent="Header"]
+layout_mode = 2
+text = "Download"
+
+[node name="LogDisplay" type="RichTextLabel" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+bbcode_enabled = true
+scroll_active = true
+scroll_following = true
+
+[node name="StatusLabel" type="RichTextLabel" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 32)
+bbcode_enabled = true
+scroll_active = false

--- a/devdocs/platform_gui_handbook.md
+++ b/devdocs/platform_gui_handbook.md
@@ -11,9 +11,16 @@ Follow these steps whenever you need to work inside the Platform GUI:
 1. **Open the Godot project** – Launch Godot 4.4 and open `project.godot` from the repository root. The GUI scene tree expects the `RNGProcessor` autoload to be active, so do not create a blank project or rename the root folder.
 2. **Confirm autoloads** – In the Godot editor, open **Project > Project Settings > Autoload** and verify that `RNGManager`, `NameGenerator`, and `RNGProcessor` are all enabled. These singletons are the bridges between the GUI and the middleware. If any are missing, press the refresh icon to reload project settings or re-add them by pointing to the corresponding `.gd` files in `res://autoloads/`.
 3. **Run the GUI scene** – Press <kbd>F5</kbd> (or click the play icon) to launch the default scene. The Platform GUI window should appear with tabs for *Generators*, *Seeds*, and *Debug Logs*.
-4. **Optional: enable DebugRNG logging** – If you want the GUI to collect detailed telemetry, toggle the "Record DebugRNG Session" option in the toolbar before running any generators. This attaches the helper via `RNGProcessor.set_debug_rng(...)` so the middleware starts writing the session report immediately.
+4. **Optional: enable DebugRNG logging** – If you want the GUI to collect detailed telemetry, open the DebugRNG toolbar, capture the session metadata (label, ticket ID, quick notes), press **Start session**, and then click **Attach**. The toolbar wires the helper through `RNGProcessor.set_debug_rng(...)` so the middleware starts writing the session report immediately.
 
 ## Common workflows
+
+### Recording DebugRNG sessions
+
+1. Open the DebugRNG toolbar (bundled with `res://addons/platform_gui/components/DebugToolbar.tscn`). Populate the metadata fields so support tickets, QA notes, and quick descriptors are stored alongside the session.
+2. Press **Start session** to create a fresh DebugRNG helper. The toolbar caches the helper and keeps it ready for attachment without touching engine singletons.
+3. Click **Attach** to route the helper through the RNGProcessor controller. The middleware now emits timeline, warning, and stream-usage telemetry directly into the recorder.
+4. Use **Detach** whenever you want to pause logging without destroying the captured session. Press **Stop** to close the report, persist the TXT file, and release the helper.
 
 ### Running a generator
 
@@ -79,9 +86,9 @@ Follow these steps whenever you need to work inside the Platform GUI:
 ### Reviewing DebugRNG logs
 
 1. Switch to the **Debug Logs** tab. When DebugRNG is active, the middleware writes to `user://debug_rng_report.txt` (or a custom path you configured earlier).
-2. Click **Refresh Log**. This button requests the latest telemetry via `RNGProcessor.get_debug_rng().read_current_log()` and updates the viewer pane.
-3. Use the sidebar filters to jump to specific sections (Generation Timeline, Stream Usage, Warnings). These anchors mirror the log layout described in the middleware manual, helping you confirm whether unexpected results came from seeds, strategy choices, or warnings recorded by `record_warning(...)`.
-4. Press **Download Log** to save a copy. The GUI calls `DebugRNG.close()` through the middleware so the file flushes to disk before presenting the system file picker.
+2. Click **Refresh log**. This button requests the latest telemetry via `RNGProcessor.get_debug_rng().read_current_log()` and updates the viewer pane without reparsing the TXT output.
+3. Use the section filter dropdown to jump between **Generation timeline**, **Warnings**, **Stream usage**, and **Strategy errors**. Highlighted entries mirror the telemetry schema—warnings render with the ⚠️ glyph while failures and strategy errors are tinted red—so analysts can scan for issues in seconds.
+4. Enter a target file (for example `user://debug_rng_copy.txt`) and press **Download** to archive the latest TXT report. The panel streams the raw file directly to disk so engineers can attach it to tickets or share it with QA leads.
 
 ### Replaying and exporting seeds
 

--- a/devdocs/rng_processor_manual.md
+++ b/devdocs/rng_processor_manual.md
@@ -42,6 +42,8 @@ The class lives at `res://name_generator/RNGProcessor.gd` and can be retrieved a
 - `generation_completed(request_config, result, metadata)` – Fired after a successful run. `result` is the raw payload returned by the active strategy.
 - `generation_failed(request_config, error, metadata)` – Fired when the generator is missing or a strategy reports a structured error. The signal payload mirrors the dictionary returned by `NameGenerator.generate`.
 - `set_debug_rng(debug_rng: DebugRNG, attach_to_debug := true)` / `get_debug_rng()` – Attach or inspect a `DebugRNG` observer. When `attach_to_debug` is `true`, the helper automatically begins monitoring lifecycle signals and propagates itself to `NameGenerator` so strategy-level events are also captured.
+- `DebugRNG.get_log_path()` / `DebugRNG.is_session_open()` – Surface the persisted log location and whether telemetry is still streaming so UI layers can reflect recorder state without peeking into private members.
+- `DebugRNG.read_current_log()` – Retrieve the in-memory telemetry payload as structured dictionaries. The Platform GUI consumes this call to render section filters (timeline, warnings, stream usage, strategy errors) without reparsing the TXT output.
 
 These surface areas are what the Platform GUI will observe. By listening to the signals, the UI can show per-request timelines, associate results with RNG stream derivations, and offer “re-run with same seed” affordances without needing private knowledge of the name generator.
 

--- a/name_generator/tools/DebugRNG.gd
+++ b/name_generator/tools/DebugRNG.gd
@@ -184,6 +184,36 @@ func dispose() -> void:
     ## Alias for close() to match familiar resource lifecycles.
     close()
 
+func get_log_path() -> String:
+    ## Return the current log path used when persisting reports to disk.
+    return _log_path
+
+func is_session_open() -> bool:
+    ## Surface whether DebugRNG is actively recording telemetry.
+    return _session_open
+
+func read_current_log() -> Dictionary:
+    ## Provide a structured snapshot of the in-memory telemetry payload.
+    ##
+    ## The return dictionary mirrors the sections found in the serialized
+    ## plaintext report so UI layers can filter the data without reparsing
+    ## the on-disk document. Each entry is duplicated to avoid downstream
+    ## mutation of the recorder state.
+    var report: Dictionary = {
+        "log_path": _log_path,
+        "session_open": _session_open,
+        "session_started_at": _session_started_at,
+        "session_ended_at": _session_ended_at,
+        "metadata": _duplicate_variant(_session_metadata),
+        "entries": [],
+        "stats": _duplicate_variant(_stats),
+    }
+
+    for entry in _log_entries:
+        report["entries"].append(_duplicate_variant(entry))
+
+    return report
+
 func _on_generation_started(config: Dictionary, metadata: Dictionary) -> void:
     _stats["calls_started"] += 1
     _log_entries.append({

--- a/tests/gui/test_debug_log_panel.gd
+++ b/tests/gui/test_debug_log_panel.gd
@@ -1,0 +1,109 @@
+extends RefCounted
+
+const PANEL_SCENE := preload("res://addons/platform_gui/panels/logs/DebugLogPanel.tscn")
+const DebugRNG := preload("res://name_generator/tools/DebugRNG.gd")
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _reset()
+    _run_test("renders_highlighted_sections", func(): _test_renders_highlighted_sections())
+    _run_test("downloads_latest_report", func(): _test_downloads_latest_report())
+
+    return {
+        "suite": "Platform GUI Debug Log Panel",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+        return
+    _failed += 1
+    _failures.append({"name": name, "message": String(message)})
+
+func _test_renders_highlighted_sections() -> Variant:
+    var controller := ControllerStub.new()
+    controller.debug_rng = _make_debug_rng_payload()
+
+    var panel: Control = PANEL_SCENE.instantiate()
+    panel.set_controller_override(controller)
+    panel._ready()
+    panel._on_refresh_pressed()
+
+    var text := (panel.get_node("LogDisplay") as RichTextLabel).bbcode_text
+    if text.find("⚠️") == -1:
+        return "Warnings should be highlighted with the ⚠️ glyph."
+    if text.find("‼") == -1:
+        return "Strategy errors should be highlighted with the ‼ glyph."
+
+    panel._on_section_selected(2) # warnings
+    text = (panel.get_node("LogDisplay") as RichTextLabel).bbcode_text
+    if text.find("⚠️") == -1 or text.find("stream=") != -1:
+        return "Warnings filter should isolate warning entries."
+
+    panel._on_section_selected(3) # stream usage
+    text = (panel.get_node("LogDisplay") as RichTextLabel).bbcode_text
+    if text.find("stream=") == -1:
+        return "Stream usage filter should include stream telemetry entries."
+    return null
+
+func _test_downloads_latest_report() -> Variant:
+    var controller := ControllerStub.new()
+    var debug_rng := _make_debug_rng_payload()
+    debug_rng.close()
+    controller.debug_rng = debug_rng
+
+    var panel: Control = PANEL_SCENE.instantiate()
+    panel.set_controller_override(controller)
+    panel._ready()
+    panel._on_refresh_pressed()
+
+    var target_path := "user://debug_rng_copy_test.txt"
+    if FileAccess.file_exists(target_path):
+        DirAccess.remove_absolute(ProjectSettings.globalize_path(target_path))
+
+    (panel.get_node("Header/DownloadPath") as LineEdit).text = target_path
+    panel._on_download_pressed()
+
+    if not FileAccess.file_exists(target_path):
+        return "Download helper should write the DebugRNG report to disk."
+    var expected := FileAccess.get_file_as_string(debug_rng.get_log_path())
+    var actual := FileAccess.get_file_as_string(target_path)
+    if expected != actual:
+        return "Downloaded log should match the source DebugRNG report."
+
+    DirAccess.remove_absolute(ProjectSettings.globalize_path(target_path))
+    return null
+
+func _make_debug_rng_payload() -> DebugRNG:
+    var debug_rng := DebugRNG.new()
+    debug_rng.begin_session({"label": "Test session"})
+    debug_rng._on_generation_started({"strategy": "wordlist"}, {"strategy_id": "wordlist", "seed": "alpha", "rng_stream": "wordlist::default"})
+    debug_rng._on_generation_failed({"strategy": "wordlist"}, {"code": "validation_error"}, {"strategy_id": "wordlist"})
+    debug_rng.record_warning("Sample warning", {"context": "unit"})
+    debug_rng.record_stream_usage("wordlist::default", {"details": "token"})
+    debug_rng._on_strategy_error("invalid_config", "Strategy failed", {}, "wordlist")
+    return debug_rng
+
+func _reset() -> void:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+class ControllerStub:
+    extends Node
+
+    var debug_rng: Object = null
+
+    func get_debug_rng() -> Object:
+        return debug_rng

--- a/tests/gui/test_debug_toolbar.gd
+++ b/tests/gui/test_debug_toolbar.gd
@@ -1,0 +1,115 @@
+extends RefCounted
+
+const TOOLBAR_SCENE := preload("res://addons/platform_gui/components/DebugToolbar.tscn")
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _reset()
+    _run_test("starts_session_and_captures_metadata", func(): _test_starts_session_and_captures_metadata())
+    _run_test("attaches_and_detaches_helper", func(): _test_attaches_and_detaches_helper())
+    _run_test("stop_closes_session_and_detaches", func(): _test_stop_closes_session_and_detaches())
+
+    return {
+        "suite": "Platform GUI Debug Toolbar",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+        return
+    _failed += 1
+    _failures.append({"name": name, "message": String(message)})
+
+func _test_starts_session_and_captures_metadata() -> Variant:
+    var toolbar: Control = TOOLBAR_SCENE.instantiate()
+    toolbar._ready()
+    (toolbar.get_node("SessionLabel") as LineEdit).text = "QA Session"
+    (toolbar.get_node("TicketInput") as LineEdit).text = "BUG-123"
+    (toolbar.get_node("NotesInput") as LineEdit).text = "Repro on macOS"
+
+    toolbar._on_start_pressed()
+
+    var debug_rng := toolbar.get_active_debug_rng()
+    if debug_rng == null:
+        return "Toolbar should create a DebugRNG instance when starting a session."
+    var payload := debug_rng.read_current_log()
+    var metadata: Dictionary = payload.get("metadata", {})
+    if metadata.get("label", "") != "QA Session":
+        return "Session metadata should include the provided label."
+    if metadata.get("ticket", "") != "BUG-123":
+        return "Session metadata should include the provided ticket identifier."
+    if metadata.get("notes", "") != "Repro on macOS":
+        return "Session metadata should include the notes field."
+    return null
+
+func _test_attaches_and_detaches_helper() -> Variant:
+    var toolbar: Control = TOOLBAR_SCENE.instantiate()
+    var controller := ControllerStub.new()
+    toolbar.set_controller_override(controller)
+    toolbar._ready()
+    toolbar._on_start_pressed()
+
+    toolbar._on_attach_pressed()
+    if controller.attach_calls != 1:
+        return "Attach button should forward the DebugRNG instance to the controller."
+    if controller.last_debug_rng != toolbar.get_active_debug_rng():
+        return "Controller should receive the active DebugRNG instance."
+
+    toolbar._on_detach_pressed()
+    if controller.detach_calls != 1:
+        return "Detach button should clear the DebugRNG helper through the controller."
+    if controller.last_debug_rng != null:
+        return "Controller should no longer reference the helper after detaching."
+    return null
+
+func _test_stop_closes_session_and_detaches() -> Variant:
+    var toolbar: Control = TOOLBAR_SCENE.instantiate()
+    var controller := ControllerStub.new()
+    toolbar.set_controller_override(controller)
+    toolbar._ready()
+    toolbar._on_start_pressed()
+    var debug_rng := toolbar.get_active_debug_rng()
+    toolbar._on_attach_pressed()
+
+    toolbar._on_stop_pressed()
+
+    if toolbar.get_active_debug_rng() != null:
+        return "Stop button should dispose of the active DebugRNG instance."
+    if controller.detach_calls == 0:
+        return "Stop button should detach the helper from the controller."
+    if debug_rng.is_session_open():
+        return "DebugRNG session should be closed after pressing stop."
+    return null
+
+func _reset() -> void:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+class ControllerStub:
+    extends Node
+
+    var last_debug_rng: Object = null
+    var attach_calls: int = 0
+    var detach_calls: int = 0
+
+    func set_debug_rng(debug_rng: Object, attach_to_debug: bool = true) -> void:
+        last_debug_rng = debug_rng
+        if debug_rng == null:
+            detach_calls += 1
+        else:
+            attach_calls += 1
+
+    func get_debug_rng() -> Object:
+        return last_debug_rng

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -41,6 +41,14 @@
       "path": "res://tests/gui/test_hybrid_pipeline_panel.gd"
     },
     {
+      "name": "Platform GUI Debug Toolbar Suite",
+      "path": "res://tests/gui/test_debug_toolbar.gd"
+    },
+    {
+      "name": "Platform GUI Debug Log Panel Suite",
+      "path": "res://tests/gui/test_debug_log_panel.gd"
+    },
+    {
       "name": "Formulas Workspace Suite",
       "path": "res://tests/gui/test_formulas_workspace.gd"
     },


### PR DESCRIPTION
## Summary
- add a DebugRNG toolbar component so Platform GUI users can capture session metadata, start/stop logging, and attach helpers through the controller
- introduce a Debug Log panel that renders structured DebugRNG telemetry with section filters and download support
- expose DebugRNG helper state/read APIs, extend documentation, and cover the UI with regression tests

## Testing
- `godot --headless --script res://tests/run_all_tests.gd` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb869ae36c8320b08bc696bc6b14a5