### PR TITLE
Add dataset inspector panel and documentation updates

### DIFF
--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
@@ -1,0 +1,289 @@
+extends VBoxContainer
+
+## Platform GUI panel that runs the dataset inspector script from inside the editor.
+##
+## Artists can audit dataset folders without leaving Godot: the panel executes the
+## existing `dataset_inspector.gd` tool via the editor API, captures stdout/warning
+## messages, and renders folder health inline. Quick-launch helpers expose the
+## Syllable Set Builder plugin plus direct links to the dataset authoring guide so
+## narrative teams can jump straight into remediation work.
+
+@export var dataset_inspector_script_path: String = "res://name_generator/tools/dataset_inspector.gd"
+@export var dataset_docs_path: String = "res://devdocs/datasets.md"
+
+const STDOUT_CHANNEL := StringName("stdout")
+const STDERR_CHANNEL := StringName("stderr")
+const WARNING_CHANNELS := [
+    StringName("warning"),
+    StringName("user_warning"),
+    StringName("script_warning"),
+]
+const ERROR_CHANNELS := [
+    StringName("error"),
+    StringName("user_error"),
+    StringName("script_error"),
+]
+
+const _INFO_COLOR := Color(0.27, 0.56, 0.86)
+const _WARNING_COLOR := Color(0.82, 0.49, 0.09)
+const _ERROR_COLOR := Color(0.86, 0.23, 0.23)
+
+@onready var _inspect_button: Button = %InspectButton
+@onready var _builder_button: Button = %SyllableBuilderButton
+@onready var _docs_button: Button = %DocsButton
+@onready var _status_label: RichTextLabel = %StatusLabel
+@onready var _results_display: RichTextLabel = %ResultDisplay
+@onready var _warnings_block: VBoxContainer = %WarningsBlock
+@onready var _warnings_display: RichTextLabel = %WarningsDisplay
+@onready var _context_label: RichTextLabel = %ContextLabel
+
+var _editor_interface_override: Object = null
+var _external_open_override: Callable = Callable()
+
+func _ready() -> void:
+    _status_label.bbcode_enabled = true
+    _results_display.bbcode_enabled = true
+    _warnings_display.bbcode_enabled = true
+    _context_label.bbcode_enabled = true
+    _inspect_button.pressed.connect(_on_inspect_pressed)
+    _builder_button.pressed.connect(_on_builder_pressed)
+    _docs_button.pressed.connect(_on_docs_pressed)
+    _context_label.meta_clicked.connect(_on_context_meta_clicked)
+    _refresh_context_message()
+    _render_idle_state()
+
+func set_editor_interface_override(interface: Object) -> void:
+    ## Inject an editor-interface stub for automated tests.
+    _editor_interface_override = interface
+
+func clear_editor_interface_override() -> void:
+    _editor_interface_override = null
+
+func set_external_open_override(callable: Callable) -> void:
+    ## Override external opening behaviour (e.g. during tests).
+    _external_open_override = callable
+
+func clear_external_open_override() -> void:
+    _external_open_override = Callable()
+
+func set_dataset_inspector_script_path(path: String) -> void:
+    dataset_inspector_script_path = path.strip_edges()
+
+func set_dataset_docs_path(path: String) -> void:
+    dataset_docs_path = path.strip_edges()
+    _refresh_context_message()
+
+func run_inspection() -> void:
+    ## Execute the dataset inspector script and render the captured output.
+    var capture := _execute_inspector()
+    _render_capture(capture)
+
+func get_status_bbcode() -> String:
+    return _status_label.bbcode_text
+
+func get_results_bbcode() -> String:
+    return _results_display.bbcode_text
+
+func get_warnings_bbcode() -> String:
+    return _warnings_display.bbcode_text
+
+func _on_inspect_pressed() -> void:
+    run_inspection()
+
+func _on_builder_pressed() -> void:
+    var editor := _get_editor_interface()
+    if editor == null:
+        _set_status("Enable the Syllable Set Builder plugin from Project > Project Settings > Plugins.", "warning")
+        return
+    if editor.has_method("set_plugin_enabled"):
+        editor.call("set_plugin_enabled", "Syllable Set Builder", true)
+    _set_status("Requested Syllable Set Builder activation. Check the right dock for \"Syllable Sets\".")
+
+func _on_docs_pressed() -> void:
+    _open_dataset_docs()
+
+func _on_context_meta_clicked(meta: Variant) -> void:
+    if String(meta) == "dataset_docs":
+        _open_dataset_docs()
+
+func _open_dataset_docs() -> void:
+    var doc_path := dataset_docs_path
+    if doc_path == "":
+        _set_status("Dataset guide path not configured.", "warning")
+        return
+    var opened := _open_external(doc_path)
+    if opened:
+        _set_status("Opened dataset authoring guide.")
+    else:
+        _set_status("Unable to open dataset guide automatically; see %s." % doc_path, "warning")
+
+func _render_idle_state() -> void:
+    _set_status("Run the dataset inspector to review folder health.")
+    _results_display.bbcode_text = "[i]No inspection has been run yet.[/i]"
+    _warnings_block.visible = false
+
+func _render_capture(capture: Dictionary) -> void:
+    var stdout_lines: Array = capture.get("stdout", [])
+    var directories := _parse_directories(stdout_lines)
+    var warnings: Array = capture.get("warnings", [])
+    var errors: Array = capture.get("errors", [])
+
+    if not errors.is_empty():
+        _set_status("Dataset inspection failed. Review the error output below.", "error")
+    elif not warnings.is_empty():
+        _set_status("Inspection completed with warnings.", "warning")
+    elif directories.is_empty():
+        _set_status("Dataset inspector did not report any folders.", "warning")
+    else:
+        _set_status("Dataset inspection completed without warnings.")
+
+    _render_directory_listing(directories)
+    _render_warning_block(warnings, errors)
+
+func _render_directory_listing(directories: Array) -> void:
+    if directories.is_empty():
+        _results_display.bbcode_text = "[i]No dataset folders were reported.[/i]"
+        return
+    var lines := PackedStringArray()
+    for entry in directories:
+        if not (entry is Dictionary):
+            continue
+        var path := String(entry.get("path", ""))
+        if path == "":
+            continue
+        lines.append("[b]%s[/b]" % path)
+        var children: Array = entry.get("children", [])
+        if children.is_empty():
+            lines.append("  • [color=%s]No files detected[/color]" % _WARNING_COLOR.to_html())
+        else:
+            for child_variant in children:
+                lines.append("  • %s" % String(child_variant))
+        lines.append("")
+    if lines.size() > 0 and lines[-1] == "":
+        lines.remove_at(lines.size() - 1)
+    _results_display.bbcode_text = "\n".join(lines)
+
+func _render_warning_block(warnings: Array, errors: Array) -> void:
+    var warning_lines := PackedStringArray()
+    for message in warnings:
+        warning_lines.append("⚠️ [color=%s]%s[/color]" % [_WARNING_COLOR.to_html(), String(message)])
+    for message in errors:
+        warning_lines.append("❌ [color=%s]%s[/color]" % [_ERROR_COLOR.to_html(), String(message)])
+    if warning_lines.is_empty():
+        _warnings_block.visible = false
+        _warnings_display.bbcode_text = ""
+    else:
+        _warnings_block.visible = true
+        _warnings_display.bbcode_text = "\n".join(warning_lines)
+
+func _execute_inspector() -> Dictionary:
+    var capture := {
+        "stdout": [],
+        "warnings": [],
+        "errors": [],
+    }
+    var script_path := dataset_inspector_script_path
+    if script_path == "":
+        capture["errors"].append("Dataset inspector path is not configured.")
+        return capture
+    if not ResourceLoader.exists(script_path):
+        capture["errors"].append("Dataset inspector not found at %s." % script_path)
+        return capture
+    var script := load(script_path)
+    if script == null:
+        capture["errors"].append("Unable to load dataset inspector script.")
+        return capture
+    capture = _capture_messages(func():
+        var instance := script.new()
+        if instance != null:
+            instance.free()
+    })
+    return capture
+
+func _capture_messages(callable: Callable) -> Dictionary:
+    var record := {
+        "stdout": [],
+        "warnings": [],
+        "errors": [],
+    }
+    var registered: Array[StringName] = []
+    var previous_setting := Engine.print_error_messages
+    Engine.print_error_messages = false
+    if EngineDebugger != null:
+        for channel in _capture_channels():
+            if EngineDebugger.has_capture(channel):
+                continue
+            var capture_callable := func(message: String, _data: Array) -> bool:
+                _record_message(record, channel, message)
+                return true
+            EngineDebugger.register_message_capture(channel, capture_callable)
+            registered.append(channel)
+    callable.call()
+    if EngineDebugger != null:
+        for channel in registered:
+            EngineDebugger.unregister_message_capture(channel)
+    Engine.print_error_messages = previous_setting
+    return record
+
+func _capture_channels() -> Array[StringName]:
+    var channels := [STDERR_CHANNEL, STDOUT_CHANNEL]
+    channels.append_array(WARNING_CHANNELS)
+    channels.append_array(ERROR_CHANNELS)
+    return channels
+
+func _record_message(record: Dictionary, channel: StringName, message: String) -> void:
+    var text := String(message).strip_edges()
+    if channel == STDOUT_CHANNEL:
+        (record["stdout"] as Array).append(text)
+    elif channel == STDERR_CHANNEL or channel in ERROR_CHANNELS:
+        (record["errors"] as Array).append(text)
+    elif channel in WARNING_CHANNELS:
+        (record["warnings"] as Array).append(text)
+
+func _parse_directories(lines: Array) -> Array:
+    var directories: Array = []
+    var current := {}
+    for variant in lines:
+        var line := String(variant)
+        if line.begins_with("  - "):
+            if current.is_empty():
+                continue
+            var children: Array = current.get("children", [])
+            children.append(line.substr(4, line.length() - 4))
+            current["children"] = children
+        elif line.strip_edges() != "":
+            if not current.is_empty():
+                directories.append(current.duplicate(true))
+            current = {"path": line.strip_edges(), "children": []}
+    if not current.is_empty():
+        directories.append(current.duplicate(true))
+    return directories
+
+func _refresh_context_message() -> void:
+    var doc_path := dataset_docs_path if dataset_docs_path != "" else "res://devdocs/datasets.md"
+    _context_label.bbcode_text = "Need guidance? Review the [url=dataset_docs]dataset production checklist[/url] before importing or regenerating assets."
+
+func _set_status(message: String, severity: String = "info") -> void:
+    var color := _INFO_COLOR
+    if severity == "warning":
+        color = _WARNING_COLOR
+    elif severity == "error":
+        color = _ERROR_COLOR
+    _status_label.bbcode_text = "[color=%s]%s[/color]" % [color.to_html(), message]
+
+func _get_editor_interface() -> Object:
+    if _editor_interface_override != null:
+        return _editor_interface_override
+    if Engine.has_singleton("EditorInterface"):
+        return Engine.get_singleton("EditorInterface")
+    return null
+
+func _open_external(path: String) -> bool:
+    if _external_open_override.is_valid():
+        _external_open_override.call(path)
+        return true
+    if not OS.has_feature("editor"):
+        return false
+    var absolute_path := ProjectSettings.globalize_path(path)
+    var error := OS.shell_open(absolute_path)
+    return error == OK

--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=2 format=3 uid="uid://datasetinspectorpanel"]
+
+[ext_resource type="Script" path="res://addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd" id="1_9p7k1"]
+
+[node name="DatasetInspectorPanel" type="VBoxContainer"]
+custom_minimum_size = Vector2(520, 0)
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+theme_override_constants/separation = 12
+script = ExtResource("1_9p7k1")
+
+[node name="Header" type="HBoxContainer" parent="."]
+theme_override_constants/separation = 8
+
+[node name="Title" type="Label" parent="Header"]
+text = "Dataset health"
+theme_override_font_sizes/font_size = 18
+
+[node name="HeaderSpacer" type="Control" parent="Header"]
+size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+[node name="InspectButton" type="Button" parent="Header"]
+text = "Inspect datasets"
+
+[node name="SyllableBuilderButton" type="Button" parent="Header"]
+text = "Open syllable builder"
+
+[node name="DocsButton" type="Button" parent="Header"]
+text = "Dataset guide"
+
+[node name="StatusLabel" type="RichTextLabel" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+fit_content = true
+scroll_active = false
+
+[node name="ResultLabel" type="Label" parent="."]
+text = "Folder contents"
+
+[node name="ResultDisplay" type="RichTextLabel" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+fit_content = true
+scroll_active = false
+
+[node name="WarningsBlock" type="VBoxContainer" parent="."]
+visible = false
+theme_override_constants/separation = 4
+
+[node name="WarningsHeader" type="Label" parent="WarningsBlock"]
+text = "Warnings"
+
+[node name="WarningsDisplay" type="RichTextLabel" parent="WarningsBlock"]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+fit_content = true
+scroll_active = false
+
+[node name="ContextLabel" type="RichTextLabel" parent="."]
+autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+fit_content = true
+scroll_active = false

--- a/devdocs/datasets.md
+++ b/devdocs/datasets.md
@@ -65,6 +65,13 @@ identifying when to regenerate derived Markov models.
 
 ## 4. Tooling during QA
 
+### Dataset inspector tab (Platform GUI)
+
+1. Open the **Dataset health** tab (`res://addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn`) from the Platform GUI toolkit. The panel invokes `dataset_inspector.gd` behind the scenes, captures stdout/warning output, and renders a per-folder summary inline so you do not need to leave the editor for a health check.【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L1-L162】
+2. Review the **Warnings** block beneath the folder listing. Empty directories or missing resources surface as ⚠️ entries with the original script message so you can fix the filesystem layout immediately.【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L101-L144】
+3. Use **Open syllable builder** when you need to regenerate syllable sets as part of the cleanup. The button enables the Syllable Set Builder plugin and points artists to the right dock without leaving the dataset workflow.【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L67-L84】【F:name_generator/tools/SyllableSetBuilder.gd†L1-L93】
+4. Follow the inline **Dataset guide** link to jump straight to this document if you need the sourcing and normalisation checklist while triaging folders.【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L85-L119】
+
 ### Dataset inspector script
 
 Run the dataset inspector in headless mode to confirm every dataset folder is

--- a/devdocs/platform_gui_handbook.md
+++ b/devdocs/platform_gui_handbook.md
@@ -75,6 +75,13 @@ Follow these steps whenever you need to work inside the Platform GUI:
 7. Review the **Token expansion preview** tree. Each row lists the recursion depth, resolved strategy display name, and the seed that TemplateStrategy will pass to the child generator. Nested template configs expand inline so you can verify cascaded definitions without leaving the panel.
 8. Press **Preview** to request a deterministic sample. Middleware validation errors reuse the metadata service's guidance (for example, empty tokens or missing strategy keys) so the fix is always spelled out next to the relevant control.
 
+### Auditing dataset health
+
+1. Switch to the **Dataset health** tab (`res://addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn`). The header button runs `dataset_inspector.gd`, captures stdout and warning output through the editor, and renders an inline folder inventory so you can triage missing assets without launching the headless tool.【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L1-L110】
+2. Review the **Warnings** stack beneath the listing. Empty directories, missing roots, or other script warnings show up with ⚠️ markers and red status text so you know exactly which folders still need content before sign-off.【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L101-L144】
+3. Use **Open syllable builder** when the inspection highlights syllable gaps. The button enables the Syllable Set Builder plugin and nudges artists toward the dock that converts curated word lists into `SyllableSetResource` files.【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L67-L84】【F:name_generator/tools/SyllableSetBuilder.gd†L1-L95】
+4. Click **Dataset guide** or the contextual link at the bottom of the panel whenever you need sourcing and normalisation reminders while you clean up the data. The shortcut jumps straight to [`devdocs/datasets.md`](./datasets.md).【F:addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd†L85-L119】
+
 ### Crafting sentence formulas
 
 1. Open the **Formulas** workspace (`res://addons/platform_gui/workspaces/formulas/FormulasWorkspace.tscn`). The top banner links to the matching anchor inside [`devdocs/sentences.md`](./sentences.md) so you can cross-reference the original blueprint while you work.

--- a/tests/gui/test_dataset_inspector_panel.gd
+++ b/tests/gui/test_dataset_inspector_panel.gd
@@ -1,0 +1,102 @@
+extends RefCounted
+
+const PANEL_SCENE := preload("res://addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn")
+const STUB_SCRIPT_PATH := "res://tests/test_assets/dataset_inspector_stub.gd"
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _reset()
+    _run_test("renders_directory_listing", func(): _test_renders_directory_listing())
+    _run_test("reports_warnings", func(): _test_reports_warnings())
+    _run_test("opens_docs_via_external_override", func(): _test_opens_docs_via_external_override())
+    _run_test("activates_syllable_builder", func(): _test_activates_syllable_builder())
+    return {
+        "suite": "Dataset Inspector Panel",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+    else:
+        _failed += 1
+        _failures.append({"name": name, "message": String(message)})
+
+func _test_renders_directory_listing() -> Variant:
+    var context := _make_panel()
+    var panel := context["panel"]
+    panel.set_dataset_inspector_script_path(STUB_SCRIPT_PATH)
+    panel.run_inspection()
+    var results := panel.get_results_bbcode()
+    if results.find("res://tests/tmp_data/alpha") == -1:
+        return "Directory heading should be rendered in the results block."
+    if results.find("creatures.txt") == -1 or results.find("items.csv") == -1:
+        return "Child entries should be listed beneath the directory heading."
+    context["panel"].free()
+    return null
+
+func _test_reports_warnings() -> Variant:
+    var context := _make_panel()
+    var panel := context["panel"]
+    panel.set_dataset_inspector_script_path(STUB_SCRIPT_PATH)
+    panel.run_inspection()
+    var warnings := panel.get_warnings_bbcode()
+    if warnings.find("⚠️") == -1:
+        return "Warnings block should include an inline warning glyph."
+    if warnings.find("beta is empty") == -1:
+        return "Warning messages emitted by the inspector should surface in the panel."
+    context["panel"].free()
+    return null
+
+func _test_opens_docs_via_external_override() -> Variant:
+    var context := _make_panel()
+    var panel := context["panel"]
+    var recorded: Array[String] = []
+    panel.set_external_open_override(func(path: String): recorded.append(path))
+    panel._on_docs_pressed()
+    if recorded.size() != 1:
+        return "Docs button should invoke external opener once."
+    if recorded[0] != panel.dataset_docs_path:
+        return "Docs button should forward the dataset guide path to the opener."
+    context["panel"].free()
+    return null
+
+func _test_activates_syllable_builder() -> Variant:
+    var context := _make_panel()
+    var panel := context["panel"]
+    var editor := EditorInterfaceStub.new()
+    panel.set_editor_interface_override(editor)
+    panel._on_builder_pressed()
+    if editor.activation_requests != ["Syllable Set Builder"]:
+        return "Syllable builder quick-launch should request plugin activation."
+    context["panel"].free()
+    return null
+
+func _make_panel() -> Dictionary:
+    var panel := PANEL_SCENE.instantiate()
+    panel._ready()
+    return {"panel": panel}
+
+func _reset() -> void:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()
+
+class EditorInterfaceStub:
+    extends RefCounted
+
+    var activation_requests: Array[String] = []
+
+    func set_plugin_enabled(name: String, enabled: bool) -> void:
+        if enabled:
+            activation_requests.append(name)

--- a/tests/test_assets/dataset_inspector_stub.gd
+++ b/tests/test_assets/dataset_inspector_stub.gd
@@ -1,0 +1,8 @@
+extends SceneTree
+
+func _init():
+    print("res://tests/tmp_data/alpha")
+    print("  - creatures.txt")
+    print("  - items.csv")
+    push_warning("res://tests/tmp_data/beta is empty")
+    quit()

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -49,6 +49,10 @@
       "path": "res://tests/gui/test_debug_log_panel.gd"
     },
     {
+      "name": "Platform GUI Dataset Inspector Panel Suite",
+      "path": "res://tests/gui/test_dataset_inspector_panel.gd"
+    },
+    {
       "name": "Formulas Workspace Suite",
       "path": "res://tests/gui/test_formulas_workspace.gd"
     },


### PR DESCRIPTION
## Summary
- add a Platform GUI dataset health tab that runs the dataset_inspector tool and surfaces warnings inline
- provide quick-launch hooks for the Syllable Set Builder and link back to the dataset production checklist
- cover the new workflow with automated GUI tests and documentation updates for artists

## Testing
- godot --headless --script res://tests/run_all_tests.gd *(fails: command not found in container)*
- godot4 --headless --script res://tests/run_all_tests.gd *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb89ca26e483209762ab7ac25e298d