### PR TITLE
Improve accessibility focus for new platform panels

### DIFF
--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://datasetinspectorpanel"]
+[gd_scene load_steps=3 format=3 uid="uid://datasetinspectorpanel"]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd" id="1_9p7k1"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_2m7yt"]
 
 [node name="DatasetInspectorPanel" type="VBoxContainer"]
 custom_minimum_size = Vector2(520, 0)
@@ -21,12 +22,18 @@ size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
 [node name="InspectButton" type="Button" parent="Header"]
 text = "Inspect datasets"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_2m7yt")
 
 [node name="SyllableBuilderButton" type="Button" parent="Header"]
 text = "Open syllable builder"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_2m7yt")
 
 [node name="DocsButton" type="Button" parent="Header"]
 text = "Dataset guide"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_2m7yt")
 
 [node name="StatusLabel" type="RichTextLabel" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART

--- a/addons/platform_gui/panels/hybrid/HybridPipelinePanel.gd
+++ b/addons/platform_gui/panels/hybrid/HybridPipelinePanel.gd
@@ -79,6 +79,7 @@ func _ready() -> void:
     _alias_edit.text_changed.connect(_on_alias_changed)
     _template_edit.text_changed.connect(_on_template_changed)
     _seed_edit.text_changed.connect(_on_seed_changed)
+    _seed_edit.text_submitted.connect(_on_seed_submitted)
     _preview_button.pressed.connect(_on_preview_button_pressed)
     %RefreshButton.pressed.connect(_on_refresh_pressed)
     _pipeline_tree.columns = 5
@@ -298,6 +299,10 @@ func _on_seed_changed(_text: String) -> void:
     var step := _get_selected_step()
     _update_step_details(step)
     _notify_configuration_changed()
+
+func _on_seed_submitted(text: String) -> void:
+    _seed_edit.text = text
+    _on_preview_button_pressed()
 
 func _on_preview_button_pressed() -> void:
     var controller := _get_controller()

--- a/addons/platform_gui/panels/hybrid/HybridPipelinePanel.tscn
+++ b/addons/platform_gui/panels/hybrid/HybridPipelinePanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://hybridpipelinepanel"]
+[gd_scene load_steps=3 format=3 uid="uid://hybridpipelinepanel"]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/hybrid/HybridPipelinePanel.gd" id="1_rksh5"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_j56sy"]
 
 [node name="HybridPipelinePanel" type="VBoxContainer"]
 custom_minimum_size = Vector2(620, 0)
@@ -23,6 +24,8 @@ size_flags_horizontal = Control.SIZE_EXPAND_FILL
 flat = true
 text = "Refresh"
 tooltip_text = "Reload strategy metadata."
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="MetadataSummary" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -42,6 +45,8 @@ text = "Pipeline seed"
 [node name="SeedInput" type="LineEdit" parent="SeedRow"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 placeholder_text = "Optional parent seed"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="SeedHelper" type="Label" parent="PipelineControls"]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -58,6 +63,8 @@ custom_minimum_size = Vector2(0, 80)
 placeholder_text = "Forged from $material, this $item hums with $effect."
 scroll_fit_content_height = true
 wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="PipelineOverviewLabel" type="Label" parent="."]
 text = "Pipeline overview"
@@ -67,6 +74,8 @@ columns = 5
 custom_minimum_size = Vector2(0, 200)
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 size_flags_vertical = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="EditorSection" type="HBoxContainer" parent="."]
 theme_override_constants/separation = 12
@@ -87,18 +96,26 @@ theme_override_constants/separation = 6
 
 [node name="StrategySelector" type="OptionButton" parent="StepControls"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="AddStepButton" type="Button" parent="StepControls"]
 text = "Add"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="RemoveStepButton" type="Button" parent="StepControls"]
 text = "Remove"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="StepList" type="ItemList" parent="StepSidebar"]
 allow_rearrange = true
 custom_minimum_size = Vector2(0, 220)
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 size_flags_vertical = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="StepDetails" type="VBoxContainer" parent="EditorSection"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -114,6 +131,8 @@ text = "Alias"
 editable = false
 placeholder_text = "store_as alias"
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="StepMetadataLabel" type="RichTextLabel" parent="StepDetails"]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -149,6 +168,8 @@ theme_override_constants/separation = 12
 
 [node name="PreviewButton" type="Button" parent="PreviewRow"]
 text = "Preview"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_j56sy")
 
 [node name="PreviewSpacer" type="Control" parent="PreviewRow"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL

--- a/addons/platform_gui/panels/logs/DebugLogPanel.gd
+++ b/addons/platform_gui/panels/logs/DebugLogPanel.gd
@@ -38,6 +38,7 @@ func _ready() -> void:
     _refresh_button.pressed.connect(_on_refresh_pressed)
     _download_button.pressed.connect(_on_download_pressed)
     _section_selector.item_selected.connect(_on_section_selected)
+    _download_path.text_submitted.connect(_on_download_path_submitted)
     _populate_sections()
     _update_display()
 
@@ -88,6 +89,10 @@ func _on_download_pressed() -> void:
         return
     file.store_string(content)
     _set_status("Saved DebugRNG report to %s." % target_path)
+
+func _on_download_path_submitted(text: String) -> void:
+    _download_path.text = text
+    _on_download_pressed()
 
 func _on_section_selected(index: int) -> void:
     _section_selector.selected = index

--- a/addons/platform_gui/panels/logs/DebugLogPanel.tscn
+++ b/addons/platform_gui/panels/logs/DebugLogPanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/logs/DebugLogPanel.gd" id="1_r9a7o"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_rqdjh"]
 
 [node name="DebugLogPanel" type="VBoxContainer"]
 layout_mode = 2
@@ -15,20 +16,28 @@ size_flags_horizontal = 3
 [node name="RefreshButton" type="Button" parent="Header"]
 layout_mode = 2
 text = "Refresh log"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_rqdjh")
 
 [node name="SectionSelector" type="OptionButton" parent="Header"]
 layout_mode = 2
 size_flags_horizontal = 1
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_rqdjh")
 
 [node name="DownloadPath" type="LineEdit" parent="Header"]
 layout_mode = 2
 size_flags_horizontal = 3
 custom_minimum_size = Vector2(240, 0)
 placeholder_text = "user://debug_rng_copy.txt"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_rqdjh")
 
 [node name="DownloadButton" type="Button" parent="Header"]
 layout_mode = 2
 text = "Download"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_rqdjh")
 
 [node name="LogDisplay" type="RichTextLabel" parent="."]
 layout_mode = 2

--- a/addons/platform_gui/panels/markov/MarkovPanel.gd
+++ b/addons/platform_gui/panels/markov/MarkovPanel.gd
@@ -40,6 +40,7 @@ func _ready() -> void:
     _preview_button.pressed.connect(_on_preview_button_pressed)
     %RefreshButton.pressed.connect(_on_refresh_pressed)
     _resource_list.item_selected.connect(_on_resource_selected)
+    _seed_edit.text_submitted.connect(_on_seed_submitted)
     _refresh_metadata()
     _refresh_resource_catalog()
     _update_preview_state(null)
@@ -116,6 +117,10 @@ func _on_preview_button_pressed() -> void:
         "status": "success",
         "message": String(response),
     })
+
+func _on_seed_submitted(text: String) -> void:
+    _seed_edit.text = text
+    _on_preview_button_pressed()
 
 func _refresh_metadata() -> void:
     var service := _get_metadata_service()

--- a/addons/platform_gui/panels/markov/MarkovPanel.tscn
+++ b/addons/platform_gui/panels/markov/MarkovPanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://markovpanel"]
+[gd_scene load_steps=3 format=3 uid="uid://markovpanel"]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/markov/MarkovPanel.gd" id="1_s8t7f"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_kr4tw"]
 
 [node name="MarkovPanel" type="VBoxContainer"]
 custom_minimum_size = Vector2(520, 0)
@@ -23,6 +24,8 @@ size_flags_horizontal = Control.SIZE_EXPAND_FILL
 flat = true
 text = "Refresh"
 tooltip_text = "Reload strategy metadata and the resource catalogue."
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_kr4tw")
 
 [node name="MetadataSummary" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -45,6 +48,8 @@ custom_minimum_size = Vector2(0, 220)
 select_mode = ItemList.SELECT_SINGLE
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 size_flags_vertical = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_kr4tw")
 
 [node name="ResourceSummary" type="RichTextLabel" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -80,6 +85,8 @@ max_value = 128.0
 min_value = 0.0
 step = 1.0
 value = 0.0
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_kr4tw")
 
 [node name="PreviewRow" type="HBoxContainer" parent="."]
 theme_override_constants/separation = 12
@@ -90,9 +97,13 @@ text = "Seed"
 [node name="SeedInput" type="LineEdit" parent="PreviewRow"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 placeholder_text = "Optional seed label"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_kr4tw")
 
 [node name="PreviewButton" type="Button" parent="PreviewRow"]
 text = "Preview"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_kr4tw")
 
 [node name="ValidationLabel" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART

--- a/addons/platform_gui/panels/seeds/SeedsDashboardPanel.tscn
+++ b/addons/platform_gui/panels/seeds/SeedsDashboardPanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://seeds_dashboard_panel"]
+[gd_scene load_steps=3 format=3 uid="uid://seeds_dashboard_panel"]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/seeds/SeedsDashboardPanel.gd" id="1"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_1ac4o"]
 
 [node name="SeedsDashboardPanel" type="VBoxContainer"]
 script = ExtResource("1")
@@ -25,18 +26,26 @@ size_flags_horizontal = 1
 unique_name_in_owner = true
 size_flags_horizontal = 3
 placeholder_text = "Enter master seed"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="ApplySeedButton" type="Button" parent="SeedHeader"]
 unique_name_in_owner = true
 text = "Apply"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="RandomizeButton" type="Button" parent="SeedHeader"]
 unique_name_in_owner = true
 text = "Randomize"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="RefreshButton" type="Button" parent="SeedHeader"]
 unique_name_in_owner = true
 text = "Refresh"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="StatusLabel" type="RichTextLabel" parent="."]
 unique_name_in_owner = true
@@ -60,6 +69,8 @@ size_flags_vertical = 3
 allow_reselect = true
 columns = 4
 hide_root = true
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="RoutingLabel" type="Label" parent="."]
 text = "Stream routing preview"
@@ -70,6 +81,8 @@ unique_name_in_owner = true
 size_flags_vertical = 3
 columns = 4
 hide_root = true
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="ExportControls" type="HBoxContainer" parent="."]
 size_flags_horizontal = 3
@@ -77,12 +90,18 @@ size_flags_horizontal = 3
 [node name="ExportButton" type="Button" parent="ExportControls"]
 unique_name_in_owner = true
 text = "Export state"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="ImportButton" type="Button" parent="ExportControls"]
 unique_name_in_owner = true
 text = "Import state"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")
 
 [node name="ExportText" type="TextEdit" parent="."]
 unique_name_in_owner = true
 size_flags_vertical = 3
 placeholder_text = "Seed export will appear here. Paste a saved JSON payload to import."
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_1ac4o")

--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
@@ -13,6 +13,7 @@ extends VBoxContainer
 @export var metadata_service_path: NodePath
 
 const SyllableSetResource := preload("res://name_generator/resources/SyllableSetResource.gd")
+const FOCUS_STYLE := preload("res://addons/platform_gui/themes/focus_highlight.tres")
 
 @onready var _resource_list: ItemList = %ResourceList
 @onready var _resource_summary_label: Label = %ResourceSummary
@@ -74,6 +75,7 @@ func _ready() -> void:
     %RefreshButton.pressed.connect(_on_refresh_pressed)
     _resource_list.item_selected.connect(_on_resource_selected)
     _require_middle_toggle.toggled.connect(_on_require_middle_toggled)
+    _seed_edit.text_submitted.connect(_on_seed_submitted)
     _build_regex_preset_controls()
     _track_default_modulate(_resource_list)
     _track_default_modulate(_middle_min_spin)
@@ -140,6 +142,10 @@ func _on_require_middle_toggled(pressed: bool) -> void:
     if pressed and _middle_max_spin.value < 1:
         _middle_max_spin.value = 1
 
+func _on_seed_submitted(text: String) -> void:
+    _seed_edit.text = text
+    _on_preview_button_pressed()
+
 func _build_regex_preset_controls() -> void:
     for child in _regex_preset_container.get_children():
         child.queue_free()
@@ -154,6 +160,8 @@ func _build_regex_preset_controls() -> void:
         var button := CheckBox.new()
         button.text = String(preset.get("label", identifier.capitalize()))
         button.tooltip_text = String(preset.get("description", ""))
+        button.focus_mode = Control.FOCUS_ALL
+        button.theme_override_styles["focus"] = FOCUS_STYLE
         _regex_preset_container.add_child(button)
         _regex_presets[identifier] = {
             "definition": preset,

--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.tscn
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://syllablechainpanel"]
+[gd_scene load_steps=3 format=3 uid="uid://syllablechainpanel"]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd" id="1_w9vaf"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_d2y25"]
 
 [node name="SyllableChainPanel" type="VBoxContainer"]
 custom_minimum_size = Vector2(520, 0)
@@ -23,6 +24,8 @@ size_flags_horizontal = Control.SIZE_EXPAND_FILL
 flat = true
 text = "Refresh"
 tooltip_text = "Reload strategy metadata and the resource catalogue."
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="MetadataSummary" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -45,6 +48,8 @@ custom_minimum_size = Vector2(0, 220)
 select_mode = ItemList.SELECT_SINGLE
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 size_flags_vertical = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="ResourceSummary" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -55,6 +60,8 @@ theme_override_constants/separation = 8
 
 [node name="RequireMiddle" type="CheckButton" parent="OptionsSection"]
 text = "Require at least one middle syllable"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="MiddleRangeRow" type="HBoxContainer" parent="OptionsSection"]
 theme_override_constants/separation = 6
@@ -76,6 +83,8 @@ max_value = 32.0
 min_value = 0.0
 step = 1.0
 value = 0.0
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="MiddleMaxLabel" type="Label" parent="OptionsSection/MiddleRangeRow"]
 text = "Max"
@@ -88,6 +97,8 @@ max_value = 32.0
 min_value = 0.0
 step = 1.0
 value = 1.0
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="MinLengthRow" type="HBoxContainer" parent="OptionsSection"]
 theme_override_constants/separation = 6
@@ -106,6 +117,8 @@ max_value = 64.0
 min_value = 0.0
 step = 1.0
 value = 0.0
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="RegexSection" type="VBoxContainer" parent="OptionsSection"]
 theme_override_constants/separation = 4
@@ -126,9 +139,13 @@ text = "Seed"
 [node name="SeedInput" type="LineEdit" parent="PreviewRow"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 placeholder_text = "Optional seed label"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="PreviewButton" type="Button" parent="PreviewRow"]
 text = "Preview"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_d2y25")
 
 [node name="ValidationLabel" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART

--- a/addons/platform_gui/panels/template/TemplatePanel.gd
+++ b/addons/platform_gui/panels/template/TemplatePanel.gd
@@ -47,6 +47,7 @@ func _ready() -> void:
     _sub_generators_edit.text_changed.connect(_on_sub_generators_changed)
     _max_depth_spin.value_changed.connect(_on_max_depth_changed)
     _seed_edit.text_changed.connect(_on_seed_changed)
+    _seed_edit.text_submitted.connect(_on_seed_submitted)
     _token_tree.set_column_titles_visible(true)
     _token_tree.set_column_title(0, "Node")
     _token_tree.set_column_title(1, "Depth")
@@ -181,6 +182,10 @@ func _on_preview_button_pressed() -> void:
     })
     _update_seed_helper()
     _notify_configuration_changed()
+
+func _on_seed_submitted(text: String) -> void:
+    _seed_edit.text = text
+    _on_preview_button_pressed()
 
 func _refresh_metadata() -> void:
     var service := _get_metadata_service()

--- a/addons/platform_gui/panels/template/TemplatePanel.tscn
+++ b/addons/platform_gui/panels/template/TemplatePanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://templatepanel"]
+[gd_scene load_steps=3 format=3 uid="uid://templatepanel"]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/template/TemplatePanel.gd" id="1_zl6r1"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_l5smr"]
 
 [node name="TemplatePanel" type="VBoxContainer"]
 custom_minimum_size = Vector2(520, 0)
@@ -23,6 +24,8 @@ size_flags_horizontal = Control.SIZE_EXPAND_FILL
 flat = true
 text = "Refresh"
 tooltip_text = "Reload strategy metadata."
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_l5smr")
 
 [node name="MetadataSummary" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -43,6 +46,8 @@ custom_minimum_size = Vector2(0, 80)
 placeholder_text = "Forge a [material] blade for the [title]."
 scroll_fit_content_height = true
 wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_l5smr")
 
 [node name="MaxDepthRow" type="HBoxContainer" parent="."]
 theme_override_constants/separation = 8
@@ -56,6 +61,8 @@ max_value = 64.0
 min_value = 1.0
 step = 1.0
 value = 8.0
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_l5smr")
 
 [node name="SeedRow" type="HBoxContainer" parent="."]
 theme_override_constants/separation = 8
@@ -66,6 +73,8 @@ text = "Seed"
 [node name="SeedInput" type="LineEdit" parent="SeedRow"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 placeholder_text = "Optional seed label"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_l5smr")
 
 [node name="SeedHelper" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -82,6 +91,8 @@ custom_minimum_size = Vector2(0, 140)
 placeholder_text = "{\n    \"material\": {\"strategy\": \"wordlist\", \"wordlist_paths\": []},\n    \"title\": {\"strategy\": \"template\", \"template_string\": \"[rank] of [order]\"}\n}"
 scroll_fit_content_height = true
 wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_l5smr")
 
 [node name="TokenTreeLabel" type="Label" parent="."]
 text = "Token expansion preview"
@@ -92,6 +103,8 @@ custom_minimum_size = Vector2(0, 220)
 select_mode = Tree.SELECT_ROW
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 size_flags_vertical = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_l5smr")
 
 [node name="ValidationLabel" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -107,6 +120,8 @@ theme_override_constants/separation = 12
 
 [node name="PreviewButton" type="Button" parent="PreviewRow"]
 text = "Preview"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_l5smr")
 
 [node name="PreviewSpacer" type="Control" parent="PreviewRow"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL

--- a/addons/platform_gui/panels/wordlist/WordlistPanel.gd
+++ b/addons/platform_gui/panels/wordlist/WordlistPanel.gd
@@ -34,6 +34,7 @@ var _resource_cache: Array = []
 func _ready() -> void:
     _preview_button.pressed.connect(_on_preview_button_pressed)
     %RefreshButton.pressed.connect(_on_refresh_pressed)
+    _seed_edit.text_submitted.connect(_on_seed_submitted)
     _refresh_metadata()
     _refresh_resource_catalog()
     _update_preview_state(null)
@@ -118,6 +119,10 @@ func apply_config_payload(config: Dictionary) -> void:
 
 func _on_refresh_pressed() -> void:
     refresh()
+
+func _on_seed_submitted(text: String) -> void:
+    _seed_edit.text = text
+    _on_preview_button_pressed()
 
 func _refresh_metadata() -> void:
     var service := _get_metadata_service()

--- a/addons/platform_gui/panels/wordlist/WordlistPanel.tscn
+++ b/addons/platform_gui/panels/wordlist/WordlistPanel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://wordlistpanel"]
+[gd_scene load_steps=3 format=3 uid="uid://wordlistpanel"]
 
 [ext_resource type="Script" path="res://addons/platform_gui/panels/wordlist/WordlistPanel.gd" id="1_x0gui"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="2_z1lhr"]
 
 [node name="WordlistPanel" type="VBoxContainer"]
 custom_minimum_size = Vector2(480, 0)
@@ -23,6 +24,8 @@ size_flags_horizontal = Control.SIZE_EXPAND_FILL
 flat = true
 text = "Refresh"
 tooltip_text = "Reload strategy metadata and the resource catalogue."
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="MetadataSummary" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -45,12 +48,16 @@ custom_minimum_size = Vector2(0, 220)
 select_mode = ItemList.SELECT_MULTI
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 size_flags_vertical = Control.SIZE_EXPAND_FILL
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="OptionsSection" type="HBoxContainer" parent="."]
 theme_override_constants/separation = 12
 
 [node name="UseWeights" type="CheckButton" parent="OptionsSection"]
 text = "Use weights when available"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="DelimiterContainer" type="HBoxContainer" parent="OptionsSection"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -63,6 +70,8 @@ text = "Delimiter"
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 text = " "
 tooltip_text = "Leave blank to use a single space between selections."
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="PreviewRow" type="HBoxContainer" parent="."]
 theme_override_constants/separation = 12
@@ -73,9 +82,13 @@ text = "Seed"
 [node name="SeedInput" type="LineEdit" parent="PreviewRow"]
 size_flags_horizontal = Control.SIZE_EXPAND_FILL
 placeholder_text = "Optional seed label"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="PreviewButton" type="Button" parent="PreviewRow"]
 text = "Preview"
+focus_mode = Control.FOCUS_ALL
+theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="ValidationLabel" type="Label" parent="."]
 autowrap_mode = TextServer.AUTOWRAP_WORD_SMART

--- a/addons/platform_gui/themes/focus_highlight.tres
+++ b/addons/platform_gui/themes/focus_highlight.tres
@@ -1,0 +1,17 @@
+[gd_resource type="StyleBoxFlat" format=3]
+
+[resource]
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.239216, 0.517647, 0.878431, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+draw_center = false
+expand_margin_left = 2
+expand_margin_top = 2
+expand_margin_right = 2
+expand_margin_bottom = 2


### PR DESCRIPTION
## Summary
- add a reusable focus highlight style for platform GUI controls so keyboard users receive a visible indicator
- update the new platform panels to opt into the shared focus style, ensure controls accept keyboard focus, and wire Enter submissions for primary actions

## Testing
- godot --headless --script res://tests/run_all_tests.gd *(fails: command not found)*
- godot4 --headless --script res://tests/run_all_tests.gd *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb995243508320998e5d382a9886f7