### PR TITLE
Fix GUI panel parse issues

### DIFF
--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
@@ -197,7 +197,7 @@ func _execute_inspector() -> Dictionary:
         var instance := script.new()
         if instance != null:
             instance.free()
-    })
+    )
     return capture
 
 func _capture_messages(callable: Callable) -> Dictionary:

--- a/addons/platform_gui/panels/logs/DebugLogPanel.gd
+++ b/addons/platform_gui/panels/logs/DebugLogPanel.gd
@@ -147,7 +147,8 @@ func _render_session_header() -> PackedStringArray:
     var ended := String(_report_cache.get("session_ended_at", "--"))
     var active := bool(_report_cache.get("session_open", false))
     lines.append("[b]Session started:[/b] %s" % started)
-    lines.append("[b]Session ended:[/b] %s" % (active ? "(active)" : ended))
+    var ended_label := "(active)" if active else ended
+    lines.append("[b]Session ended:[/b] %s" % ended_label)
 
     var metadata_variant := _report_cache.get("metadata", {})
     if metadata_variant is Dictionary and not (metadata_variant as Dictionary).is_empty():

--- a/addons/platform_gui/panels/seeds/SeedsDashboardPanel.gd
+++ b/addons/platform_gui/panels/seeds/SeedsDashboardPanel.gd
@@ -114,7 +114,8 @@ func _refresh_streams(controller: Object) -> void:
         else:
             stream_item.set_tooltip_text(0, "Seed provided by RNGManager.")
 
-    _import_status.text = mode == "fallback" ? "Fallback streams active" : "RNGManager authoritative"
+    var status_text := "Fallback streams active" if mode == "fallback" else "RNGManager authoritative"
+    _import_status.text = status_text
 
 func _refresh_routing(controller: Object) -> void:
     _routing_tree.clear()
@@ -230,4 +231,3 @@ func _update_status(message: String) -> void:
 
 func _format_error(message: String) -> String:
     return "[color=%s]%s[/color]" % [_ERROR_COLOR.to_html(), message]
-*** End


### PR DESCRIPTION
## Summary
- repair the dataset inspector panel capture closure so the helper callable parses correctly
- replace deprecated ternary operators in the debug log and seeds dashboard panels with GDScript if expressions for Godot 4.4 compatibility
- remove a stray sentinel line from the seeds dashboard panel that broke parsing

## Testing
- `python tools/gdscript_parse_helper.py addons/platform_gui`
- `godot --headless --path . --check` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cba04c02748320b956a2112abf506e