### PR TITLE
Reseed RNG streams when master seed changes

### DIFF
--- a/name_generator/RNGManager.gd
+++ b/name_generator/RNGManager.gd
@@ -18,7 +18,9 @@ func _ready() -> void:
 
 func set_master_seed(seed_value: int) -> void:
     _master_seed = seed_value
-    _streams.clear()
+    for stream_name in _streams.keys():
+        var rng: RandomNumberGenerator = _streams[stream_name]
+        _initialize_stream(stream_name, rng)
 
 func get_master_seed() -> int:
     return _master_seed
@@ -80,6 +82,9 @@ func randi_range(stream_name: String, minimum: int, maximum: int) -> int:
 
 func _create_stream(name: String) -> RandomNumberGenerator:
     var rng: RandomNumberGenerator = RandomNumberGenerator.new()
+    return _initialize_stream(name, rng)
+
+func _initialize_stream(name: String, rng: RandomNumberGenerator) -> RandomNumberGenerator:
     var seed: int = _compute_stream_seed(name)
     rng.seed = seed
     rng.state = seed

--- a/tests/test_rng_manager_seed_reset.gd
+++ b/tests/test_rng_manager_seed_reset.gd
@@ -1,0 +1,68 @@
+extends RefCounted
+
+const RNGManager := preload("res://name_generator/RNGManager.gd")
+
+var _total := 0
+var _passed := 0
+var _failed := 0
+var _failures: Array[Dictionary] = []
+
+func run() -> Dictionary:
+    _reset()
+
+    _run_test("reseed_existing_streams", func(): _test_reseed_existing_streams())
+
+    return {
+        "suite": "RNG Manager Seed Reset",
+        "total": _total,
+        "passed": _passed,
+        "failed": _failed,
+        "failures": _failures.duplicate(true),
+    }
+
+func _run_test(name: String, callable: Callable) -> void:
+    _total += 1
+    var message := callable.call()
+    if message == null:
+        _passed += 1
+        return
+
+    _failed += 1
+    _failures.append({
+        "name": name,
+        "message": String(message),
+    })
+
+func _test_reseed_existing_streams() -> Variant:
+    var manager := RNGManager.new()
+    manager.set_master_seed(1111)
+
+    var stream_name := "alpha"
+    var rng := manager.get_rng(stream_name)
+
+    # Advance the RNG to ensure reseeding replaces the state rather than leaving it untouched.
+    _ = rng.randf()
+
+    manager.set_master_seed(2222)
+
+    var expected_seed := manager._compute_stream_seed(stream_name)
+    var expected_rng := RandomNumberGenerator.new()
+    expected_rng.seed = expected_seed
+    expected_rng.state = expected_seed
+
+    var observed_value := rng.randf()
+    var expected_value := expected_rng.randf()
+
+    if not is_equal_approx(observed_value, expected_value):
+        return "Reseeded RNG stream must align with the value produced by the new master seed."
+
+    if rng.seed != expected_seed or rng.state != rng.seed:
+        return "Reseeded RNG stream must expose the updated seed and reset state."
+
+    return null
+
+func _reset() -> void:
+    _total = 0
+    _passed = 0
+    _failed = 0
+    _failures.clear()

--- a/tests/tests_manifest.json
+++ b/tests/tests_manifest.json
@@ -21,6 +21,10 @@
       "path": "res://tests/test_rng_processor_headless.gd"
     },
     {
+      "name": "RNG Manager Seed Reset Suite",
+      "path": "res://tests/test_rng_manager_seed_reset.gd"
+    },
+    {
       "name": "Platform GUI RNG Processor Controller Suite",
       "path": "res://tests/platform_gui/test_rng_processor_controller.gd"
     },


### PR DESCRIPTION
## Summary
- reseed existing RNG streams when the master seed changes instead of discarding them
- centralize stream initialization so new streams match reseeded ones
- add a regression suite that verifies previously acquired RNGs respect the updated master seed and register it in the manifest

## Testing
- godot --headless --script res://tests/run_all_tests.gd *(fails: `godot` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cba1386334832099a15fc927f25ad3