### PR TITLE
Add accessible status indicators and persist GUI preferences

### DIFF
--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
@@ -28,6 +28,12 @@ const _INFO_COLOR := Color(0.27, 0.56, 0.86)
 const _WARNING_COLOR := Color(0.82, 0.49, 0.09)
 const _ERROR_COLOR := Color(0.86, 0.23, 0.23)
 
+const _STATUS_ICONS := {
+    "info": "ℹ️",
+    "warning": "⚠️",
+    "error": "❌",
+}
+
 @onready var _inspect_button: Button = %InspectButton
 @onready var _builder_button: Button = %SyllableBuilderButton
 @onready var _docs_button: Button = %DocsButton
@@ -265,11 +271,12 @@ func _refresh_context_message() -> void:
 
 func _set_status(message: String, severity: String = "info") -> void:
     var color := _INFO_COLOR
+    var icon := _STATUS_ICONS.get(severity, _STATUS_ICONS["info"])
     if severity == "warning":
         color = _WARNING_COLOR
     elif severity == "error":
         color = _ERROR_COLOR
-    _status_label.bbcode_text = "[color=%s]%s[/color]" % [color.to_html(), message]
+    _status_label.bbcode_text = "[color=%s]%s %s[/color]" % [color.to_html(), icon, message]
 
 func _get_editor_interface() -> Object:
     if _editor_interface_override != null:

--- a/addons/platform_gui/services/platform_preferences.gd
+++ b/addons/platform_gui/services/platform_preferences.gd
@@ -1,0 +1,34 @@
+extends RefCounted
+
+## Lightweight persistence helper for Platform GUI user preferences.
+##
+## Preferences are stored in a ConfigFile under `user://` so editor
+## customisations (e.g. last selected strategy or seed overrides) survive
+## restarts. The helper intentionally exposes a minimal API to keep
+## call-sites explicit and testable.
+
+const _CONFIG_PATH := "user://platform_gui_prefs.cfg"
+
+## Load a stored preference value.
+##
+## `section` groups related keys (e.g. panel identifiers) and `key`
+## refers to the specific setting to retrieve. `default_value` is
+## returned when the preference has not been written yet.
+static func load_value(section: String, key: String, default_value: Variant = null) -> Variant:
+    var config := ConfigFile.new()
+    var error := config.load(_CONFIG_PATH)
+    if error != OK:
+        return default_value
+    return config.get_value(section, key, default_value)
+
+## Persist a preference value.
+##
+## The helper silently initialises the underlying ConfigFile when the
+## preference file does not exist yet so panels can call it opportunistically.
+static func save_value(section: String, key: String, value: Variant) -> void:
+    var config := ConfigFile.new()
+    var error := config.load(_CONFIG_PATH)
+    if error != OK:
+        config = ConfigFile.new()
+    config.set_value(section, key, value)
+    config.save(_CONFIG_PATH)


### PR DESCRIPTION
## Summary
- add a shared Platform GUI preferences helper for reading/writing user settings under `user://`
- persist the last master seed entry in the Seeds dashboard and the hybrid workspace strategy/seed selections
- upgrade toolbar, log, dataset, and seed panels to render dual-coded (icon + colour) status messages for better accessibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbff61ccac8320976afad8fa59dd77