### PR TITLE
Ensure RNG streams stay in sync after reseeding

### DIFF
--- a/name_generator/RNGManager.gd
+++ b/name_generator/RNGManager.gd
@@ -20,7 +20,7 @@ func set_master_seed(seed_value: int) -> void:
     _master_seed = seed_value
     for stream_name in _streams.keys():
         var rng: RandomNumberGenerator = _streams[stream_name]
-        _initialize_stream(stream_name, rng)
+        _streams[stream_name] = _initialize_stream(stream_name, rng)
 
 func get_master_seed() -> int:
     return _master_seed

--- a/tests/test_rng_manager_seed_reset.gd
+++ b/tests/test_rng_manager_seed_reset.gd
@@ -11,6 +11,7 @@ func run() -> Dictionary:
     _reset()
 
     _run_test("reseed_existing_streams", func(): _test_reseed_existing_streams())
+    _run_test("new_streams_use_updated_seed", func(): _test_new_streams_use_updated_seed())
 
     return {
         "suite": "RNG Manager Seed Reset",
@@ -58,6 +59,34 @@ func _test_reseed_existing_streams() -> Variant:
 
     if rng.seed != expected_seed or rng.state != rng.seed:
         return "Reseeded RNG stream must expose the updated seed and reset state."
+
+    return null
+
+func _test_new_streams_use_updated_seed() -> Variant:
+    var manager := RNGManager.new()
+    manager.set_master_seed(7007)
+
+    var initial_rng := manager.get_rng("baseline")
+    _ = initial_rng.randf()
+
+    manager.set_master_seed(9090)
+
+    var new_stream_name := "delta"
+    var observed_rng := manager.get_rng(new_stream_name)
+
+    var expected_seed := manager._compute_stream_seed(new_stream_name)
+    if observed_rng.seed != expected_seed:
+        return "Streams created after reseeding must adopt the seed derived from the updated master seed."
+
+    var expected_rng := RandomNumberGenerator.new()
+    expected_rng.seed = expected_seed
+    expected_rng.state = expected_seed
+
+    var observed_value := observed_rng.randf()
+    var expected_value := expected_rng.randf()
+
+    if not is_equal_approx(observed_value, expected_value):
+        return "New streams must reproduce the deterministic sequence defined by the updated master seed."
 
     return null
 


### PR DESCRIPTION
## Summary
- reseed cached RNG streams when the master seed changes instead of clearing the cache
- cover reseed behavior with regression checks for existing and newly created streams

## Testing
- `godot --headless --script res://tests/test_rng_manager_seed_reset.gd` *(fails: `godot` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc00d9f5888320b925269aac748d2a