### PR TITLE
Fix Codex CLI scripts to support direct execution

### DIFF
--- a/tools/codex_preflight.py
+++ b/tools/codex_preflight.py
@@ -36,6 +36,12 @@ from typing import Iterable, List, Optional, Sequence
 
 from gdscript_parse_helper import collect_issues, iter_gd_files, read_context
 
+# ---------------------------------------------------------------------------
+# Allow the helper to be executed directly with ``python tools/codex_preflight.py``.
+# See ``codex_run_manifest_tests`` for the detailed explanation.
+if __package__ is None:  # pragma: no cover - import side effect
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from tools import codex_run_manifest_tests as manifest_runner
 
 

--- a/tools/codex_run_manifest_tests.py
+++ b/tools/codex_run_manifest_tests.py
@@ -36,6 +36,19 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence
 from xml.etree import ElementTree
 
+# ---------------------------------------------------------------------------
+# Ensure the repository root is importable when the module is executed as a
+# script via ``python tools/codex_run_manifest_tests.py``.
+#
+# Python initialises ``sys.path[0]`` with the directory containing the script
+# being executed.  When this file is launched directly that directory is the
+# ``tools`` folder itself, which means attempts to import ``tools.*`` resolve to
+# ``<tools>/tools`` instead of the repository root.  By appending the parent of
+# this file we make the top level package discoverable without affecting module
+# executions (where ``__package__`` is populated by the interpreter).
+if __package__ is None:  # pragma: no cover - import side effect
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from tools.codex_godot_process_manager import CodexGodotProcessManager
 
 


### PR DESCRIPTION
## Summary
- ensure the manifest test runner amends sys.path when executed directly so imports resolve correctly
- update the preflight helper with the same adjustment to keep both CLIs runnable from the repository root

## Testing
- python tools/codex_run_manifest_tests.py --project-root . --godot-binary godot4 *(fails: godot4 executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc185e8b5c8320a69a20af7ceb6064