### PR TITLE
Normalize WordlistPanel scene constants for headless tests

### DIFF
--- a/addons/platform_gui/panels/wordlist/WordlistPanel.tscn
+++ b/addons/platform_gui/panels/wordlist/WordlistPanel.tscn
@@ -5,8 +5,8 @@
 
 [node name="WordlistPanel" type="VBoxContainer"]
 custom_minimum_size = Vector2(480, 0)
-size_flags_horizontal = Control.SIZE_EXPAND_FILL
-size_flags_vertical = Control.SIZE_EXPAND_FILL
+size_flags_horizontal = 3
+size_flags_vertical = 3
 theme_override_constants/separation = 12
 script = ExtResource("1_x0gui")
 
@@ -18,21 +18,24 @@ theme_override_font_sizes/font_size = 18
 text = "Word List Strategy"
 
 [node name="HeaderSpacer" type="Control" parent="Header"]
-size_flags_horizontal = Control.SIZE_EXPAND_FILL
+size_flags_horizontal = 3
 
 [node name="RefreshButton" type="Button" parent="Header"]
+unique_name_in_owner = true
 flat = true
 text = "Refresh"
 tooltip_text = "Reload strategy metadata and the resource catalogue."
-focus_mode = Control.FOCUS_ALL
+focus_mode = 2
 theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="MetadataSummary" type="Label" parent="."]
-autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+unique_name_in_owner = true
+autowrap_mode = 3
 text = ""
 
 [node name="NotesLabel" type="Label" parent="."]
-autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+unique_name_in_owner = true
+autowrap_mode = 3
 text = ""
 
 [node name="ResourceSection" type="VBoxContainer" parent="."]
@@ -42,35 +45,38 @@ theme_override_constants/separation = 4
 text = "Available word lists"
 
 [node name="ResourceList" type="ItemList" parent="ResourceSection"]
+unique_name_in_owner = true
 allow_reselect = true
 allow_rmb_select = true
 custom_minimum_size = Vector2(0, 220)
-select_mode = ItemList.SELECT_MULTI
-size_flags_horizontal = Control.SIZE_EXPAND_FILL
-size_flags_vertical = Control.SIZE_EXPAND_FILL
-focus_mode = Control.FOCUS_ALL
+select_mode = 1
+size_flags_horizontal = 3
+size_flags_vertical = 3
+focus_mode = 2
 theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="OptionsSection" type="HBoxContainer" parent="."]
 theme_override_constants/separation = 12
 
 [node name="UseWeights" type="CheckButton" parent="OptionsSection"]
+unique_name_in_owner = true
 text = "Use weights when available"
-focus_mode = Control.FOCUS_ALL
+focus_mode = 2
 theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="DelimiterContainer" type="HBoxContainer" parent="OptionsSection"]
-size_flags_horizontal = Control.SIZE_EXPAND_FILL
-size_flags_vertical = Control.SIZE_FILL
+size_flags_horizontal = 3
+size_flags_vertical = 1
 
 [node name="DelimiterLabel" type="Label" parent="OptionsSection/DelimiterContainer"]
 text = "Delimiter"
 
 [node name="DelimiterInput" type="LineEdit" parent="OptionsSection/DelimiterContainer"]
-size_flags_horizontal = Control.SIZE_EXPAND_FILL
+unique_name_in_owner = true
+size_flags_horizontal = 3
 text = " "
 tooltip_text = "Leave blank to use a single space between selections."
-focus_mode = Control.FOCUS_ALL
+focus_mode = 2
 theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="PreviewRow" type="HBoxContainer" parent="."]
@@ -80,23 +86,27 @@ theme_override_constants/separation = 12
 text = "Seed"
 
 [node name="SeedInput" type="LineEdit" parent="PreviewRow"]
-size_flags_horizontal = Control.SIZE_EXPAND_FILL
+unique_name_in_owner = true
+size_flags_horizontal = 3
 placeholder_text = "Optional seed label"
-focus_mode = Control.FOCUS_ALL
+focus_mode = 2
 theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="PreviewButton" type="Button" parent="PreviewRow"]
+unique_name_in_owner = true
 text = "Preview"
-focus_mode = Control.FOCUS_ALL
+focus_mode = 2
 theme_override_styles/focus = ExtResource("2_z1lhr")
 
 [node name="ValidationLabel" type="Label" parent="."]
-autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+unique_name_in_owner = true
+autowrap_mode = 3
 self_modulate = Color(0.870588, 0.196078, 0.203922, 1)
 visible = false
 
 [node name="PreviewOutput" type="RichTextLabel" parent="."]
-autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+unique_name_in_owner = true
+autowrap_mode = 3
 bbcode_enabled = true
 fit_content = true
 scroll_active = false

--- a/tools/fix_wordlist_panel_tscn.py
+++ b/tools/fix_wordlist_panel_tscn.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Normalise the WordlistPanel scene for headless test execution."""
+from __future__ import annotations
+
+from pathlib import Path
+
+TSCN_PATH = Path("addons/platform_gui/panels/wordlist/WordlistPanel.tscn")
+
+REPLACEMENTS = {
+    "Control.SIZE_EXPAND_FILL": "3",
+    "Control.SIZE_EXPAND": "2",
+    "Control.SIZE_FILL": "1",
+    "Control.FOCUS_ALL": "2",
+    "ItemList.SELECT_MULTI": "1",
+    "TextServer.AUTOWRAP_WORD_SMART": "3",
+}
+
+UNIQUE_NODES = {
+    "RefreshButton",
+    "ResourceList",
+    "UseWeights",
+    "DelimiterInput",
+    "SeedInput",
+    "PreviewButton",
+    "PreviewOutput",
+    "ValidationLabel",
+    "MetadataSummary",
+    "NotesLabel",
+}
+
+
+def ensure_unique_name(lines: list[str]) -> list[str]:
+    result: list[str] = []
+    total = len(lines)
+    index = 0
+    while index < total:
+        line = lines[index]
+        result.append(line)
+        if line.startswith("[node ") and "name=\"" in line:
+            name = line.split("name=\"")[1].split("\"")[0]
+            if name in UNIQUE_NODES:
+                has_flag = False
+                lookahead = index + 1
+                while lookahead < total:
+                    next_line = lines[lookahead]
+                    if next_line.startswith("["):
+                        break
+                    if "unique_name_in_owner" in next_line:
+                        has_flag = True
+                        break
+                    if next_line.strip() == "":
+                        # stop before blank separator
+                        break
+                    lookahead += 1
+                if not has_flag:
+                    result.append("unique_name_in_owner = true")
+        index += 1
+    return result
+
+
+def main() -> None:
+    text = TSCN_PATH.read_text(encoding="utf-8")
+    for token, value in REPLACEMENTS.items():
+        text = text.replace(token, value)
+    lines = text.splitlines()
+    updated_lines = ensure_unique_name(lines)
+    new_text = "\n".join(updated_lines) + "\n"
+    if new_text == text + ("\n" if not text.endswith("\n") else ""):
+        print("No changes necessary.")
+        return
+    TSCN_PATH.write_text(new_text, encoding="utf-8")
+    print("Updated", TSCN_PATH)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace enum tokens in `WordlistPanel.tscn` with literal values so the headless parser can load the scene
- mark UI controls used by `%` shortcuts as `unique_name_in_owner` to restore onready lookups during tests
- add a helper script that applies the scene normalization automatically for future edits

## Testing
- `godot4 --headless --path . --script res://tests/run_all_tests.gd` *(fails: existing Markov panel parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2b25ad108320a501ee7964d0ea18