### PR TITLE
Fix Godot GUI script parse errors for headless checks

### DIFF
--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
@@ -195,12 +195,16 @@ func _execute_inspector() -> Dictionary:
     if not ResourceLoader.exists(script_path):
         capture["errors"].append("Dataset inspector not found at %s." % script_path)
         return capture
-    var script := load(script_path)
-    if script == null:
+    var script_resource := load(script_path)
+    if script_resource == null:
         capture["errors"].append("Unable to load dataset inspector script.")
         return capture
+    if not (script_resource is Script):
+        capture["errors"].append("Dataset inspector must be a valid Script resource.")
+        return capture
+    var inspector_script: Script = script_resource
     capture = _capture_messages(func():
-        var instance := script.new()
+        var instance: Object = inspector_script.new()
         if instance != null:
             instance.free()
     )

--- a/utils/ArrayUtils.gd
+++ b/utils/ArrayUtils.gd
@@ -5,7 +5,7 @@
 ## deterministic whenever a custom [RandomNumberGenerator] instance is
 ## provided, which is useful for tests and replay systems.  When no RNG is
 ## provided the helpers will instantiate one on demand.
-class_name ArrayUtils
+## Script class intentionally left unnamed to avoid collisions with name_generator ArrayUtils.
 extends RefCounted
 
 ## Picks a single value from ``values`` using uniform probability.


### PR DESCRIPTION
## Summary
- guard the dataset inspector panel against non-script resources and explicitly type temporary objects so `--headless` scanning no longer fails
- adjust the wordlist panel to avoid strict typed-array assumptions, allow null preview payloads, and add a deterministic join helper compatible with headless parsing
- drop the duplicate global `class_name` from the shared ArrayUtils helper to prevent global class name collisions during project scans

## Testing
- godot4 --headless --editor --quit --path .

------
https://chatgpt.com/codex/tasks/task_e_68cc3338a2508320a5f0946267f31fa6