### PR TITLE
Add main interface scene for platform GUI

### DIFF
--- a/Main_Interface.gd
+++ b/Main_Interface.gd
@@ -1,0 +1,75 @@
+extends Control
+
+## Top-level scene that wires together the Platform GUI middleware and editor panels.
+##
+## The node instantiates local copies of the controller, metadata service, and
+## event bus so engineers can launch the interface in isolation without relying
+## on global autoloads. When the scene is ready, the middleware nodes are
+## registered as singletons and injected into every toolbar, panel, and workspace
+## so they immediately bind to live middleware state. This mirrors the runtime
+## environment shipped with the add-on while keeping the editor hierarchy fully
+## self-contained for tests and tooling.
+
+@onready var _event_bus: Node = $EventBus
+@onready var _controller: Node = $ProcessorController
+@onready var _metadata_service: Node = $StrategyMetadataService
+@onready var _middleware_consumers: Array = [
+    %DebugToolbar,
+    %WordlistPanel,
+    %SyllableChainPanel,
+    %TemplatePanel,
+    %MarkovPanel,
+    %HybridPipelinePanel,
+    %SeedsDashboardPanel,
+    %DebugLogPanel,
+    %DatasetInspectorPanel,
+    %QAPanel,
+    %FormulasWorkspace,
+]
+
+var _registered_singletons: Array = []
+
+func _ready() -> void:
+    ## Register middleware singletons and cascade overrides to the UI components.
+    _register_singleton("PlatformGUIEventBus", _event_bus)
+    _register_singleton("RNGProcessorController", _controller)
+    _register_singleton("StrategyMetadataService", _metadata_service)
+
+    if is_instance_valid(_controller) and _controller.has_method("set_event_bus_override"):
+        _controller.call("set_event_bus_override", _event_bus)
+    if is_instance_valid(_metadata_service) and _metadata_service.has_method("set_controller_override"):
+        _metadata_service.call("set_controller_override", _controller)
+
+    for consumer in _middleware_consumers:
+        if consumer == null:
+            continue
+        if consumer.has_method("set_controller_override"):
+            consumer.call("set_controller_override", _controller)
+        if consumer.has_method("set_metadata_service_override"):
+            consumer.call("set_metadata_service_override", _metadata_service)
+        if consumer.has_method("refresh"):
+            consumer.call("refresh")
+
+func _exit_tree() -> void:
+    ## Clean up registered singletons when the scene is removed from the tree.
+    for entry in _registered_singletons:
+        var name: StringName = entry.get("name", StringName())
+        var node: Object = entry.get("node")
+        if name == StringName():
+            continue
+        if Engine.has_singleton(name) and Engine.get_singleton(name) == node:
+            Engine.unregister_singleton(name)
+    _registered_singletons.clear()
+
+func _register_singleton(name: StringName, node: Object) -> void:
+    ## Register the provided node as a singleton if the slot is free.
+    if not is_instance_valid(node):
+        push_warning("Attempted to register an invalid singleton: %s" % name)
+        return
+    if Engine.has_singleton(name):
+        return
+    Engine.register_singleton(name, node)
+    _registered_singletons.append({
+        "name": name,
+        "node": node,
+    })

--- a/Main_Interface.tscn
+++ b/Main_Interface.tscn
@@ -1,0 +1,135 @@
+[gd_scene load_steps=17 format=3]
+
+[ext_resource type="PackedScene" path="res://addons/platform_gui/event_bus/PlatformGUIEventBus.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/controllers/RNGProcessorController.tscn" id="2"]
+[ext_resource type="Script" path="res://addons/platform_gui/services/strategy_metadata.gd" id="3"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/components/DebugToolbar.tscn" id="4"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/seeds/SeedsDashboardPanel.tscn" id="5"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/logs/DebugLogPanel.tscn" id="6"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/datasets/DatasetInspectorPanel.tscn" id="7"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/qa/QAPanel.tscn" id="8"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/workspaces/formulas/FormulasWorkspace.tscn" id="9"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/wordlist/WordlistPanel.tscn" id="10"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/syllable_chain/SyllableChainPanel.tscn" id="11"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/template/TemplatePanel.tscn" id="12"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/markov/MarkovPanel.tscn" id="13"]
+[ext_resource type="PackedScene" path="res://addons/platform_gui/panels/hybrid/HybridPipelinePanel.tscn" id="14"]
+[ext_resource type="StyleBox" path="res://addons/platform_gui/themes/focus_highlight.tres" id="15"]
+[ext_resource type="Script" path="res://Main_Interface.gd" id="16"]
+
+[node name="Main_Interface" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = 0.0
+offset_bottom = 0.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_styles/focus = ExtResource("15")
+script = ExtResource("16")
+
+[node name="EventBus" parent="." instance=ExtResource("1")]
+
+[node name="ProcessorController" parent="." instance=ExtResource("2")]
+
+[node name="StrategyMetadataService" type="Node" parent="."]
+script = ExtResource("3")
+
+[node name="MainLayout" type="VBoxContainer" parent="."]
+layout_mode = 2
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DebugToolbar" parent="MainLayout" instance=ExtResource("4")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MainTabs" type="TabContainer" parent="MainLayout"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Generators" type="VBoxContainer" parent="MainLayout/MainTabs"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="GeneratorPanels" type="TabContainer" parent="MainLayout/MainTabs/Generators"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="WordlistPanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("10")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="SyllableChainPanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("11")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="TemplatePanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("12")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MarkovPanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("13")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HybridPipelinePanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("14")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="SeedsDashboardPanel" parent="MainLayout/MainTabs" instance=ExtResource("5")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DebugLogPanel" parent="MainLayout/MainTabs" instance=ExtResource("6")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DatasetInspectorPanel" parent="MainLayout/MainTabs" instance=ExtResource("7")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="QAPanel" parent="MainLayout/MainTabs" instance=ExtResource("8")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="FormulasWorkspace" parent="MainLayout/MainTabs" instance=ExtResource("9")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HelpersDock" type="VBoxContainer" parent="MainLayout/MainTabs"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+editor_description = "Placeholder dock reserved for future helper widgets. Attach new tools here to inherit middleware overrides automatically."
+


### PR DESCRIPTION
## Summary
- create a top-level Main_Interface scene that instantiates the platform GUI middleware and layout
- wire middleware singletons into the debug toolbar, generators, dashboards, and workspaces so they refresh against live overrides
- add a placeholder helpers dock for future tooling within the main tab container

## Testing
- `godot4 --headless --check-only Main_Interface.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4269caf883209c92e147c8631188