### PR TITLE
Set main interface as default scene

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -10,9 +10,10 @@ config_version=5
 
 [application]
 
-config/name="New Game Project"
+config/name="RNGEN Platform GUI"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+run/main_scene="res://Main_Interface.tscn"
 
 [autoload]
 


### PR DESCRIPTION
## Summary
- rename the Godot project to "RNGEN Platform GUI"
- configure the project to load Main_Interface.tscn as the default scene

## Testing
- not run (Godot editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc452e86708320a4fb700ee93aec05