### PR TITLE
Enhance grouped QA runs

### DIFF
--- a/tests/gui/test_qa_panel.gd
+++ b/tests/gui/test_qa_panel.gd
@@ -32,14 +32,31 @@ func _run_test(name: String, callable: Callable) -> void:
 func _test_populates_catalog_and_history() -> Variant:
     var controller := StubQAController.new()
     controller.diagnostics = [{"id": "alpha", "name": "Alpha diagnostic"}]
+    var baseline_summary := controller._build_group_summary()
+    var baseline_groups := baseline_summary.get("group_summaries", [])
+    if baseline_groups is Array:
+        baseline_groups = (baseline_groups as Array).duplicate(true)
+    else:
+        baseline_groups = []
     controller.history = [{
         "run_id": "previous",
         "label": "Previous run",
-        "mode": "manifest",
+        "mode": "manifest_groups",
         "exit_code": 0,
         "log_path": "user://qa_runs/previous.log",
         "requested_at": 0,
         "completed_at": 0,
+        "aggregate_total": baseline_summary.get("aggregate_total", 0),
+        "aggregate_passed": baseline_summary.get("aggregate_passed", 0),
+        "aggregate_failed": baseline_summary.get("aggregate_failed", 0),
+        "suite_total": baseline_summary.get("suite_total", 0),
+        "suite_passed": baseline_summary.get("suite_passed", 0),
+        "suite_failed": baseline_summary.get("suite_failed", 0),
+        "diagnostic_total": baseline_summary.get("diagnostic_total", 0),
+        "diagnostic_passed": baseline_summary.get("diagnostic_passed", 0),
+        "diagnostic_failed": baseline_summary.get("diagnostic_failed", 0),
+        "overall_success": baseline_summary.get("overall_success", true),
+        "group_summaries": baseline_groups,
     }]
 
     var panel: Control = PANEL_SCENE.instantiate()
@@ -65,10 +82,12 @@ func _test_streams_suite_logs() -> Variant:
 
     panel._on_run_suite_pressed()
 
-    if panel._log_lines.size() != controller.suite_logs.size():
+    if panel._log_lines.size() != controller.total_group_log_lines():
         return "Panel should append each emitted log line."
     if panel._status_label.bbcode_text.find("successfully") == -1:
         return "Status label should report successful completion."
+    if panel._status_label.bbcode_text.find("Generator core") == -1:
+        return "Status label should include a group breakdown."
     if panel._log_path_field.text == "":
         return "Panel should expose the saved log path after completion."
     if panel._open_log_button.disabled:
@@ -90,11 +109,87 @@ class StubQAController:
 
     var diagnostics: Array = []
     var history: Array = []
-    var suite_logs := [
-        "Running suite: stub",
-        "Suite summary: 1 passed, 0 failed, 1 total.",
-        "ALL TESTS PASSED",
+    var group_payloads := [
+        {
+            "id": "generator_core",
+            "label": "Generator core suites",
+            "logs": PackedStringArray([
+                "Running suite: Generator core stub",
+                "Suite summary: 2 passed, 0 failed, 2 total.",
+                "ALL TESTS PASSED",
+            ]),
+            "summary": {
+                "exit_code": 0,
+                "aggregate_total": 2,
+                "aggregate_passed": 2,
+                "aggregate_failed": 0,
+                "suite_total": 2,
+                "suite_passed": 2,
+                "suite_failed": 0,
+                "diagnostic_total": 0,
+                "diagnostic_passed": 0,
+                "diagnostic_failed": 0,
+                "overall_success": true,
+                "failure_summaries": [],
+            },
+        },
+        {
+            "id": "platform_gui",
+            "label": "Platform GUI suites",
+            "logs": PackedStringArray([
+                "Running suite: Platform GUI stub",
+                "Suite summary: 1 passed, 0 failed, 1 total.",
+                "ALL TESTS PASSED",
+            ]),
+            "summary": {
+                "exit_code": 0,
+                "aggregate_total": 1,
+                "aggregate_passed": 1,
+                "aggregate_failed": 0,
+                "suite_total": 1,
+                "suite_passed": 1,
+                "suite_failed": 0,
+                "diagnostic_total": 0,
+                "diagnostic_passed": 0,
+                "diagnostic_failed": 0,
+                "overall_success": true,
+                "failure_summaries": [],
+            },
+        },
+        {
+            "id": "diagnostics",
+            "label": "Diagnostics",
+            "logs": PackedStringArray([
+                "Running diagnostic: Stub diagnostic",
+                "Diagnostic summary: 1 passed, 0 failed, 1 total.",
+                "ALL TESTS PASSED",
+            ]),
+            "summary": {
+                "exit_code": 0,
+                "aggregate_total": 1,
+                "aggregate_passed": 1,
+                "aggregate_failed": 0,
+                "suite_total": 0,
+                "suite_passed": 0,
+                "suite_failed": 0,
+                "diagnostic_total": 1,
+                "diagnostic_passed": 1,
+                "diagnostic_failed": 0,
+                "overall_success": true,
+                "failure_summaries": [],
+            },
+        },
     ]
+
+    func total_group_log_lines() -> int:
+        var count := 0
+        for payload in group_payloads:
+            var logs: Variant = payload.get("logs", PackedStringArray())
+            if logs is PackedStringArray:
+                count += logs.size()
+            elif logs is Array:
+                count += logs.size()
+        return count
 
     func get_available_qa_diagnostics() -> Array:
         return diagnostics.duplicate(true)
@@ -106,25 +201,34 @@ class StubQAController:
         var run_id := "run_%d" % Time.get_ticks_msec()
         var request := {
             "label": "Stub suite",
-            "mode": "manifest",
+            "mode": "manifest_groups",
             "requested_at": Time.get_ticks_msec(),
+            "groups": _build_group_descriptors(),
         }
         emit_signal("qa_run_started", run_id, request)
-        for line in suite_logs:
-            emit_signal("qa_run_output", run_id, line)
-        var record := {
-            "run_id": run_id,
-            "label": request.get("label", "Stub suite"),
-            "mode": "manifest",
-            "exit_code": 0,
-            "log_path": "user://qa_runs/%s.log" % run_id,
-            "requested_at": request.get("requested_at", 0),
-            "completed_at": Time.get_ticks_msec(),
-        }
+        var aggregated := _build_group_summary()
+        for payload in group_payloads:
+            var logs: Variant = payload.get("logs", PackedStringArray())
+            if logs is PackedStringArray:
+                for line in logs:
+                    emit_signal("qa_run_output", run_id, line)
+            elif logs is Array:
+                for line in logs:
+                    emit_signal("qa_run_output", run_id, String(line))
+        var record := aggregated.duplicate(true)
+        if record.has("logs"):
+            record.erase("logs")
+        record["run_id"] = run_id
+        record["label"] = request.get("label", "Stub suite")
+        record["mode"] = String(request.get("mode", "manifest_groups"))
+        record["log_path"] = "user://qa_runs/%s.log" % run_id
+        record["requested_at"] = request.get("requested_at", 0)
+        record["completed_at"] = Time.get_ticks_msec()
         history.insert(0, record)
         var payload := {
             "log_path": record.get("log_path", ""),
-            "result": {"exit_code": 0},
+            "logs": aggregated.get("logs", PackedStringArray()),
+            "result": record.duplicate(true),
         }
         emit_signal("qa_run_completed", run_id, payload)
         return run_id
@@ -154,4 +258,58 @@ class StubQAController:
         }
         emit_signal("qa_run_completed", run_id, payload)
         return run_id
+
+    func _build_group_descriptors() -> Array:
+        var descriptors: Array = []
+        for payload in group_payloads:
+            descriptors.append({
+                "id": payload.get("id", ""),
+                "label": payload.get("label", ""),
+            })
+        return descriptors
+
+    func _build_group_summary() -> Dictionary:
+        var aggregated := {
+            "aggregate_total": 0,
+            "aggregate_passed": 0,
+            "aggregate_failed": 0,
+            "suite_total": 0,
+            "suite_passed": 0,
+            "suite_failed": 0,
+            "diagnostic_total": 0,
+            "diagnostic_passed": 0,
+            "diagnostic_failed": 0,
+            "overall_success": true,
+            "failure_summaries": [],
+            "exit_code": 0,
+            "group_summaries": [],
+            "groups": _build_group_descriptors(),
+        }
+        var combined_logs := PackedStringArray()
+        for payload in group_payloads:
+            var summary: Dictionary = payload.get("summary", {})
+            aggregated["aggregate_total"] += int(summary.get("aggregate_total", 0))
+            aggregated["aggregate_passed"] += int(summary.get("aggregate_passed", 0))
+            aggregated["aggregate_failed"] += int(summary.get("aggregate_failed", 0))
+            aggregated["suite_total"] += int(summary.get("suite_total", 0))
+            aggregated["suite_passed"] += int(summary.get("suite_passed", 0))
+            aggregated["suite_failed"] += int(summary.get("suite_failed", 0))
+            aggregated["diagnostic_total"] += int(summary.get("diagnostic_total", 0))
+            aggregated["diagnostic_passed"] += int(summary.get("diagnostic_passed", 0))
+            aggregated["diagnostic_failed"] += int(summary.get("diagnostic_failed", 0))
+            if int(summary.get("exit_code", 0)) != 0:
+                aggregated["exit_code"] = max(aggregated.get("exit_code", 0), int(summary.get("exit_code", 0)))
+                aggregated["overall_success"] = false
+            var group_entry := summary.duplicate(true)
+            group_entry["group_id"] = payload.get("id", "")
+            group_entry["group_label"] = payload.get("label", "")
+            aggregated["group_summaries"].append(group_entry)
+            var logs: Variant = payload.get("logs", PackedStringArray())
+            if logs is PackedStringArray:
+                combined_logs.append_array(logs)
+            elif logs is Array:
+                for line in logs:
+                    combined_logs.append(String(line))
+        aggregated["logs"] = combined_logs
+        return aggregated
 *** End Patch


### PR DESCRIPTION
## Summary
- launch the grouped manifest runner through a dedicated helper so the full suite iterates the generator core, platform GUI, and diagnostics groups from `tests/tests_manifest.json`
- enrich QA completion payloads with duplicated group summaries and lookup metadata for downstream consumers
- update the QA panel guidance and status handling to surface grouped breakdowns from the aggregated payload

## Testing
- `godot --version` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4c0010188320a4f0d32be02d65df