### PR TITLE
Update documentation for grouped test runners and interface suite

### DIFF
--- a/addons/platform_gui/controllers/RNGProcessorController.gd
+++ b/addons/platform_gui/controllers/RNGProcessorController.gd
@@ -206,9 +206,11 @@ func run_full_test_suite() -> String:
     ## Launch the grouped manifest runner backed by `tests/test_suite_runner.gd`.
     ##
     ## The helper spawns a QA run that iterates the generator core, platform GUI,
-    ## and diagnostics manifest groups defined in `tests/tests_manifest.json`.
-    ## Results are merged into a single payload so downstream panels receive a
-    ## concise status alongside per-group breakdowns.
+    ## and diagnostics manifest groups defined in `tests/tests_manifest.json`,
+    ## mirroring the CLI scripts (`run_generator_tests.gd`,
+    ## `run_platform_gui_tests.gd`, and `run_diagnostics_tests.gd`). Results are
+    ## merged into a single payload so downstream panels receive a concise status
+    ## alongside per-group breakdowns.
     return _launch_qa_run(_make_grouped_manifest_request(
         TestSuiteRunner.DEFAULT_MANIFEST_PATH,
         _DEFAULT_MANIFEST_GROUPS

--- a/addons/platform_gui/panels/qa/QAPanel.gd
+++ b/addons/platform_gui/panels/qa/QAPanel.gd
@@ -2,11 +2,13 @@ extends VBoxContainer
 
 ## Panel that orchestrates regression and diagnostic runs directly from the Platform GUI.
 ##
-## The QA panel exposes quick actions for the grouped manifest runner,
+## The QA panel exposes quick actions for the grouped manifest runner
 ## streams log output as each manifest group executes, and caches recent runs so
 ## support engineers can jump to stored summaries or open generated log files.
-## Results are sourced from the RNGProcessor controller to keep middleware
-## wiring consistent with the rest of the editor tooling.
+## Results are sourced from the RNGProcessor controller, mirroring the CLI
+## scripts (`run_generator_tests.gd`, `run_platform_gui_tests.gd`, and
+## `run_diagnostics_tests.gd`), to keep middleware wiring consistent with the
+## rest of the editor tooling.
 
 @export var controller_path: NodePath
 

--- a/data/factions/README.md
+++ b/data/factions/README.md
@@ -36,6 +36,6 @@ See the core dataset workflow overview in [`devdocs/strategies.md`](../../devdoc
 Run the established tooling after adding or updating faction datasets:
 
 1. `dataset_inspector.gd` – Confirms the new `factions/` folder and highlights empty or missing resources.
-2. Regression suite – Execute `godot --headless --script res://tests/run_all_tests.gd` to ensure hybrid strategies consuming the faction data still pass.
+2. Regression suites – Execute `godot --headless --script res://tests/run_generator_tests.gd` and `godot --headless --script res://tests/run_diagnostics_tests.gd` to ensure hybrid strategies consuming the faction data still pass and curated diagnostics stay green.
 
 Log QA outcomes in change reviews so other engineers can trace dataset provenance and validation history.

--- a/data/monsters/README.md
+++ b/data/monsters/README.md
@@ -71,8 +71,9 @@ Extend the chain with behaviour descriptors or habitat wordlists to produce full
   ```bash
   godot --headless --path . --script res://name_generator/tools/dataset_inspector.gd
   ```
-- Execute the project test suite after adding or updating datasets:
+- Execute the project test suites after adding or updating datasets:
   ```bash
-  godot --headless --script res://tests/run_all_tests.gd
+  godot --headless --script res://tests/run_generator_tests.gd
+  godot --headless --script res://tests/run_diagnostics_tests.gd
   ```
 - Follow the shared dataset workflow procedures outlined in [`devdocs/tooling.md`](../../devdocs/tooling.md) for import automation, naming conventions, and documentation updates.

--- a/data/objects/README.md
+++ b/data/objects/README.md
@@ -41,6 +41,7 @@ This folder holds themed vocabularies for equipment, curios, relics, and other i
   ```
 - Execute the regression suites (`pytest` equivalents live in `tests/`) so Hybrid and template pipelines stay deterministic:
   ```
-  godot --headless --path . --script res://tests/run_all.gd
+  godot --headless --path . --script res://tests/run_generator_tests.gd
+  godot --headless --path . --script res://tests/run_diagnostics_tests.gd
   ```
 - If a new resource introduces additional wordlists, update or add focused tests so failures surface through CI before designers hit broken content.

--- a/data/people/README.md
+++ b/data/people/README.md
@@ -158,7 +158,8 @@ state tracking.
   expectations still hold:
 
   ```bash
-  godot --headless --path . --script res://tests/run_all_tests.gd
+  godot --headless --path . --script res://tests/run_generator_tests.gd
+  godot --headless --path . --script res://tests/run_diagnostics_tests.gd
   ```
 
 Document the test output in your pull request so reviewers can verify the

--- a/data/places/README.md
+++ b/data/places/README.md
@@ -70,9 +70,10 @@ Follow the shared [dataset workflow guide](../../devdocs/tooling.md) when integr
    ```bash
    godot --headless --path . --script res://name_generator/tools/dataset_inspector.gd
    ```
-2. Execute the regression suite to confirm new datasets do not break strategy expectations:
+2. Execute the regression suites to confirm new datasets do not break strategy expectations:
    ```bash
-   godot --headless --script res://tests/run_all_tests.gd
+   godot --headless --script res://tests/run_generator_tests.gd
+   godot --headless --script res://tests/run_diagnostics_tests.gd
    ```
 
 Record the command output alongside merge requests so downstream engineers can trace the validation history.

--- a/data/skills_powers/README.md
+++ b/data/skills_powers/README.md
@@ -71,6 +71,7 @@ Adjust templates to fit your game’s tone while keeping placeholders aligned wi
 After updating any dataset in this folder, run the project’s regression tests to catch integration issues early:
 
 - `godot --headless --script res://name_generator/tools/dataset_inspector.gd`
-- `godot --headless --script res://tests/run_all_tests.gd`
+- `godot --headless --script res://tests/run_generator_tests.gd`
+- `godot --headless --script res://tests/run_diagnostics_tests.gd`
 
-The second command executes the full headless test manifest, ensuring hybrid and template compositions still succeed with the refreshed data.
+The latter commands execute the generator suites and curated diagnostics, ensuring hybrid and template compositions still succeed with the refreshed data.

--- a/devdocs/README.md
+++ b/devdocs/README.md
@@ -10,5 +10,7 @@ This folder centralises implementation references for engineers working on the r
 After updating configurations, run the regression suite to confirm deterministic guarantees remain intact:
 
 ```bash
-godot --headless --script res://tests/run_all_tests.gd
+godot --headless --script res://tests/run_generator_tests.gd
+godot --headless --script res://tests/run_platform_gui_tests.gd
+godot --headless --script res://tests/run_diagnostics_tests.gd
 ```

--- a/devdocs/datasets.md
+++ b/devdocs/datasets.md
@@ -104,7 +104,8 @@ After updating datasets or derived resources, run the automated regression
 suite to ensure the content still satisfies the strategy contracts:
 
 ```bash
-godot --headless --script res://tests/run_all_tests.gd
+godot --headless --script res://tests/run_generator_tests.gd
+godot --headless --script res://tests/run_diagnostics_tests.gd
 ```
 
-Include the command and its output in QA notes so reviewers can verify the run.
+Include both command outputs in QA notes so reviewers can verify strategy and diagnostic coverage for the refreshed datasets.

--- a/devdocs/platform_gui_handbook.md
+++ b/devdocs/platform_gui_handbook.md
@@ -10,7 +10,7 @@ Follow these steps whenever you need to work inside the Platform GUI. The conden
 
 1. **Open the Godot project** – Launch Godot 4.4 and open `project.godot` from the repository root. The GUI scene tree expects the `RNGProcessor` autoload to be active, so do not create a blank project or rename the root folder.
 2. **Confirm autoloads** – In the Godot editor, open **Project > Project Settings > Autoload** and verify that `RNGManager`, `NameGenerator`, and `RNGProcessor` are all enabled. These singletons are the bridges between the GUI and the middleware. If any are missing, press the refresh icon to reload project settings or re-add them by pointing to the corresponding `.gd` files in `res://autoloads/`.
-3. **Run the GUI scene** – Press <kbd>F5</kbd> (or click the play icon) to launch the default scene. The Platform GUI window should appear with tabs for *Generators*, *Seeds*, *Debug Logs*, *Exports*, and *Admin Tools*.
+3. **Run the GUI scene** – Press <kbd>F5</kbd> (or click the play icon) to launch `Main_Interface.tscn`, the default scene that wires the Platform GUI shell together. The window should appear with tabs for *Generators*, *Seeds*, *Debug Logs*, *Exports*, and *Admin Tools*.【F:project.godot†L1-L40】【F:Main_Interface.tscn†L1-L53】
 4. **Optional: enable DebugRNG logging** – If you want the GUI to collect detailed telemetry, open the DebugRNG toolbar, capture the session metadata (label, ticket ID, quick notes), press **Start session**, and then click **Attach**. The toolbar wires the helper through `RNGProcessor.set_debug_rng(...)` so the middleware starts writing the session report immediately.
 
 ## Tab overview
@@ -147,7 +147,13 @@ Follow these steps whenever you need to work inside the Platform GUI. The conden
 
 1. Use **Export state** in the Seeds Dashboard to capture the master seed and active stream positions before committing reproductions.
 2. Attach the exported JSON to your test plan (or paste it into a fixture) so anyone can hydrate the same topology via **Import state**.
-3. Re-run the automated suite with `godot --headless --script res://tests/run_all_tests.gd` to confirm the deterministic state survives a clean restart. The command exercises every RNG Processor diagnostic, ensuring both the manager-backed and fallback routers continue to return identical results.
+3. Re-run the automated suites with:
+   ```bash
+   godot --headless --script res://tests/run_generator_tests.gd
+   godot --headless --script res://tests/run_platform_gui_tests.gd
+   godot --headless --script res://tests/run_diagnostics_tests.gd
+   ```
+   The Platform GUI run covers controller integrations and the `Main_Interface` scene test, while the generator and diagnostics runs confirm the middleware still produces deterministic results after the restart.【F:tests/run_generator_tests.gd†L1-L36】【F:tests/run_platform_gui_tests.gd†L1-L36】【F:tests/run_diagnostics_tests.gd†L1-L36】【F:tests/interface/test_main_interface_scene.gd†L1-L170】
 
 ## Accessibility and UX considerations
 

--- a/devdocs/rng_processor.md
+++ b/devdocs/rng_processor.md
@@ -27,10 +27,11 @@ If you instantiate `RNGProcessor` manually (e.g., inside an isolated test scene)
 The repository bundles regression coverage for the middleware and related components. Run the suite from the project root:
 
 ```bash
-godot --headless --script res://tests/run_all_tests.gd
+godot --headless --script res://tests/run_generator_tests.gd
+godot --headless --script res://tests/run_platform_gui_tests.gd
 ```
 
-This exercises both the in-engine tests (`name_generator/tests/*.gd`) and any headless scenarios (`tests/test_rng_processor_headless.gd`) that rely on the middleware. Attach the `DebugRNG` helper during new tests if you need additional telemetry—the suite already records warnings so logs stay informative.
+These commands exercise the in-engine tests (`name_generator/tests/*.gd`), middleware integration suites (including `tests/test_rng_processor_headless.gd`), and the Platform GUI regression coverage that consumes the controller APIs. Attach the `DebugRNG` helper during new tests if you need additional telemetry—the suites already record warnings so logs stay informative.【F:tests/test_rng_processor_headless.gd†L1-L210】【F:tests/run_generator_tests.gd†L1-L36】【F:tests/run_platform_gui_tests.gd†L1-L36】
 
 ## 4. Collecting DebugRNG logs
 

--- a/devdocs/sentences.md
+++ b/devdocs/sentences.md
@@ -185,7 +185,8 @@ Each nested seed shares the `faction_mission_demo` prefix, so any change to the 
 After updating template or hybrid configurations, run the regression suite to ensure no deterministic guarantees regressed:
 
 ```bash
-godot --headless --script res://tests/run_all_tests.gd
+godot --headless --script res://tests/run_generator_tests.gd
+godot --headless --script res://tests/run_diagnostics_tests.gd
 ```
 
-The command executes both strategy-level tests and RNGProcessor coverage, providing confidence that sentence changes still align with the engine’s deterministic contracts.
+The commands execute the strategy-level suites and curated diagnostics, providing confidence that sentence changes still align with the engine’s deterministic contracts.【F:tests/run_generator_tests.gd†L1-L36】【F:tests/run_diagnostics_tests.gd†L1-L36】

--- a/devdocs/tooling.md
+++ b/devdocs/tooling.md
@@ -26,7 +26,7 @@ Expected output:
 
 The Platform GUI now ships with a dedicated QA panel (`addons/platform_gui/panels/qa/QAPanel.tscn`) that wraps the controller's orchestration helpers. From inside the editor you can:
 
-- Launch the full regression manifest via the **Run Full Suite** action, which calls `run_all_tests.gd` through the controller and streams the console output directly into the panel log view as lines arrive.【F:addons/platform_gui/panels/qa/QAPanel.gd†L4-L115】【F:addons/platform_gui/controllers/RNGProcessorController.gd†L180-L261】
+- Launch the full regression manifest via the **Run Full Suite** action, which iterates the generator, platform GUI, and diagnostics groups through the controller using the same runner API as the headless scripts (`run_generator_tests.gd`, `run_platform_gui_tests.gd`, and `run_diagnostics_tests.gd`).【F:addons/platform_gui/panels/qa/QAPanel.gd†L4-L115】【F:addons/platform_gui/controllers/RNGProcessorController.gd†L200-L259】【F:tests/run_generator_tests.gd†L1-L36】【F:tests/run_platform_gui_tests.gd†L1-L36】【F:tests/run_diagnostics_tests.gd†L1-L36】
 - Trigger focused checks with the **Run Diagnostic** button. Diagnostics are populated from `RNGProcessorController.get_available_qa_diagnostics()` so only manifest-backed scenarios appear in the dropdown.【F:addons/platform_gui/panels/qa/QAPanel.gd†L116-L214】【F:addons/platform_gui/controllers/RNGProcessorController.gd†L118-L158】
 - Review recent executions from the history list. Each record includes exit status, timestamps, and a persisted log path. Selecting an entry restores the status summary, exposes the saved log, and enables **Open Log** for quick access to the captured Godot output.【F:addons/platform_gui/panels/qa/QAPanel.gd†L215-L330】【F:addons/platform_gui/controllers/RNGProcessorController.gd†L320-L408】
 
@@ -37,10 +37,12 @@ When regressions occur, capture both the streamed panel log and the generated De
 The QA panel forwards requests to the shared regression runner at `tests/test_suite_runner.gd`, ensuring GUI launches and headless scripts share the same execution path and log summaries.【F:addons/platform_gui/controllers/RNGProcessorController.gd†L232-L344】【F:tests/test_suite_runner.gd†L1-L160】 To reproduce the panel's behaviour without the GUI (e.g., in CI or on remote agents), invoke the Godot CLI directly from the repository root:
 
 ```bash
-godot --headless --path . --script res://tests/run_all_tests.gd
+godot --headless --path . --script res://tests/run_generator_tests.gd
+godot --headless --path . --script res://tests/run_platform_gui_tests.gd
+godot --headless --path . --script res://tests/run_diagnostics_tests.gd
 ```
 
-Always archive the stdout/stderr stream from this command. The runner streams progress line-by-line and concludes with a structured summary containing exit code, manifest coverage counts, and any failing suites—critical context for support engineers consuming CI artefacts.【F:tests/run_all_tests.gd†L1-L141】【F:tests/test_suite_runner.gd†L94-L160】
+Always archive the stdout/stderr stream from each command. The runner streams progress line-by-line and concludes with structured summaries containing exit codes, manifest coverage counts, and any failing suites—critical context for support engineers consuming CI artefacts.【F:tests/run_generator_tests.gd†L1-L36】【F:tests/run_platform_gui_tests.gd†L1-L36】【F:tests/run_diagnostics_tests.gd†L1-L36】【F:tests/test_suite_runner.gd†L94-L160】
 
 ### Diagnostics manifest
 

--- a/name_generator/README.md
+++ b/name_generator/README.md
@@ -13,7 +13,7 @@ colliding.
 - `utils/` – Shared helper scripts such as deterministic RNG routing and array
   selection helpers.
 - `tools/` – Editor and command-line utilities that support content authoring.
-- `tests/` – Regression suites executed via `tests/run_all_tests.gd`.
+- `tests/` – Regression suites executed via `tests/run_generator_tests.gd` (with additional integration suites referenced from `tests/tests_manifest.json`).
 
 ## Runtime singletons
 
@@ -97,6 +97,6 @@ nested generation without mutating the parent RNG state.
 
 ## Tests
 
-Run `godot --headless --script res://tests/run_all_tests.gd` to execute the
-suite. The manifest currently includes the general `GeneratorStrategy` tests and
-an integration suite that validates the hybrid generation pipeline.
+Run `godot --headless --script res://tests/run_generator_tests.gd` to execute the
+suite. The manifest includes the general `GeneratorStrategy` tests, middleware
+integrations, and headless scenarios that validate the hybrid generation pipeline.【F:tests/run_generator_tests.gd†L1-L36】

--- a/name_generator/tests/README.md
+++ b/name_generator/tests/README.md
@@ -19,10 +19,10 @@ This directory now contains automated coverage for the name generator module. Th
 
 ## Running the suite
 
-Use the project-wide runner script to execute every registered suite:
+Use the project-wide group runner to execute every registered suite:
 
 ```bash
-godot4 --headless --path . --script res://tests/run_all_tests.gd
+godot --headless --path . --script res://tests/run_generator_tests.gd
 ```
 
 ### Expected output

--- a/tests/README
+++ b/tests/README
@@ -2,15 +2,17 @@
 
 The project ships standalone headless scenarios alongside the manifest runner.
 
-## Aggregated manifest runner
+## Grouped manifest runners
 
-Execute every suite plus the curated diagnostics from `tests/tests_manifest.json`:
+Execute each manifest group from `tests/tests_manifest.json` as separate commands so CI logs remain focused:
 
 ```
-godot --headless --script res://tests/run_all_tests.gd
+godot --headless --script res://tests/run_generator_tests.gd
+godot --headless --script res://tests/run_platform_gui_tests.gd
+godot --headless --script res://tests/run_diagnostics_tests.gd
 ```
 
-The script prints individual suite results followed by each manifest diagnostic (including the diagnostic summaries now captured in the manifest). After all executions complete, it reports suite totals, diagnostic totals, and an overall aggregate along with a failure digest drawn from every failing test or diagnostic check.
+Each script prints suite-level results for its group, streams log output as scenarios progress, and concludes with an aggregate summary and failure digest. The Platform GUI command covers controller integrations and the `Main_Interface` scene, while the diagnostics command replays curated manifest checks.
 
 ## Focused scenarios
 

--- a/tests/test_suite_runner.gd
+++ b/tests/test_suite_runner.gd
@@ -2,7 +2,8 @@ extends RefCounted
 
 ## Helper that runs the aggregated regression suites and diagnostics used by QA tools.
 ##
-## The runner mirrors the behaviour of `tests/run_all_tests.gd` but exposes the
+## The runner powers the grouped CLI scripts (`run_generator_tests.gd`,
+## `run_platform_gui_tests.gd`, and `run_diagnostics_tests.gd`) and exposes the
 ## flow as an async-friendly API so the Platform GUI can execute automated runs
 ## without spawning an external Godot process. Callers can enable frame yields to
 ## stream log output into the editor UI while long-running suites execute.


### PR DESCRIPTION
## Summary
- Refresh README guidance to highlight the grouped manifest runner scripts and the new Main_Interface default scene.
- Update developer docs and platform GUI handbook to reference the generator, platform GUI, and diagnostics CLI commands and the interface regression suite.
- Align dataset and harness READMEs plus QA controller/panel docstrings with the renamed runners so engineers follow the new workflow.

## Testing
- Not run (documentation-only changes).


------
https://chatgpt.com/codex/tasks/task_e_68cc684f56b08320b841979ddfeea8c0