### PR TITLE
Fix Godot 4 parse errors in platform GUI scripts

### DIFF
--- a/addons/platform_gui/controllers/RNGProcessorController.gd
+++ b/addons/platform_gui/controllers/RNGProcessorController.gd
@@ -390,7 +390,7 @@ func _execute_manifest_groups(runner: Object, manifest_path: String, groups: Arr
             continue
         var group_label := String(descriptor.get("label", _resolve_group_label(group_id)))
         var group_result_variant := runner.call("run_group", manifest_path, group_id, yield_frames)
-        if group_result_variant is Object and group_result_variant.get_class() == "GDScriptFunctionState":
+        if group_result_variant is GDScriptFunctionState:
             group_result_variant = await group_result_variant
 
         var group_result: Dictionary = {}
@@ -513,7 +513,7 @@ func _process_active_qa_run() -> void:
         if runner.has_method("run_single_diagnostic"):
             var diagnostic_id := String(request.get("diagnostic_id", ""))
             var diagnostic_result_variant := runner.call("run_single_diagnostic", diagnostic_id, yield_frames)
-            if diagnostic_result_variant is Object and diagnostic_result_variant.get_class() == "GDScriptFunctionState":
+            if diagnostic_result_variant is GDScriptFunctionState:
                 diagnostic_result_variant = await diagnostic_result_variant
             if diagnostic_result_variant is Dictionary:
                 result = diagnostic_result_variant
@@ -534,9 +534,7 @@ func _process_active_qa_run() -> void:
             var groups := _normalize_manifest_groups(request.get("groups", []))
             if groups.is_empty():
                 groups = _duplicate_array(_DEFAULT_MANIFEST_GROUPS)
-            var group_result_variant := _execute_manifest_groups(runner, manifest_path, groups, yield_frames)
-            if group_result_variant is Object and group_result_variant.get_class() == "GDScriptFunctionState":
-                group_result_variant = await group_result_variant
+            var group_result_variant := await _execute_manifest_groups(runner, manifest_path, groups, yield_frames)
             if group_result_variant is Dictionary:
                 result = group_result_variant
             else:
@@ -553,7 +551,7 @@ func _process_active_qa_run() -> void:
         if runner.has_method("run_manifest"):
             var manifest_path := String(request.get("manifest_path", TestSuiteRunner.DEFAULT_MANIFEST_PATH))
             var manifest_result_variant := runner.call("run_manifest", manifest_path, yield_frames)
-            if manifest_result_variant is Object and manifest_result_variant.get_class() == "GDScriptFunctionState":
+            if manifest_result_variant is GDScriptFunctionState:
                 manifest_result_variant = await manifest_result_variant
             if manifest_result_variant is Dictionary:
                 result = manifest_result_variant

--- a/addons/platform_gui/panels/qa/QAPanel.gd
+++ b/addons/platform_gui/panels/qa/QAPanel.gd
@@ -157,7 +157,7 @@ func _on_controller_run_completed(run_id: String, payload: Dictionary) -> void:
     var group_breakdown := _format_group_breakdown_lines(_resolve_group_summaries(payload, result))
     if not group_breakdown.is_empty():
         status_lines.append_array(group_breakdown)
-    _set_status(status_lines.join("\n"))
+    _set_status(_join_strings(status_lines, "\n"))
     _active_run_id = ""
     _refresh_history()
     _update_buttons()
@@ -177,7 +177,7 @@ func _handle_run_start(run_id: String, request: Dictionary) -> void:
 
 func _append_log_line(line: String) -> void:
     _log_lines.append(line)
-    _log_view.bbcode_text = "\n".join(_log_lines)
+    _log_view.bbcode_text = _join_strings(_log_lines, "\n")
     call_deferred("_scroll_log_to_end")
 
 func _scroll_log_to_end() -> void:
@@ -260,7 +260,7 @@ func _render_history_log_hint(record: Dictionary) -> void:
     var breakdown := _format_group_breakdown_lines(_extract_group_summaries(record.get("group_summaries", [])))
     if not breakdown.is_empty():
         lines.append_array(breakdown)
-    _set_status(lines.join("\n"))
+    _set_status(_join_strings(lines, "\n"))
 
 func _get_selected_diagnostic_id() -> String:
     var selected := _diagnostic_selector.get_selected_id()
@@ -325,7 +325,7 @@ func _resolve_group_label_for_display(entry: Dictionary) -> String:
         words.append(part.capitalize())
     if words.is_empty():
         return group_id.capitalize()
-    return " ".join(words)
+    return _join_strings(words, " ")
 
 func _resolve_group_badge_code(entry: Dictionary) -> String:
     var group_id := String(entry.get("group_id", "")).strip_edges()
@@ -382,7 +382,7 @@ func _format_group_history_suffix(record: Dictionary) -> String:
         badges.append("%s%s" % [code, _resolve_group_icon(entry)])
     if badges.is_empty():
         return ""
-    return "[%s]" % " | ".join(badges)
+    return "[%s]" % _join_strings(badges, " | ")
 
 func _format_history_tooltip(record: Dictionary) -> String:
     var group_summaries := _extract_group_summaries(record.get("group_summaries", []))
@@ -395,7 +395,7 @@ func _format_history_tooltip(record: Dictionary) -> String:
             continue
         var entry: Dictionary = entry_variant
         lines.append(_format_plain_group_summary(entry))
-    return lines.join("\n")
+    return _join_strings(lines, "\n")
 
 func _ensure_controller_connections() -> void:
     var controller := _get_controller()
@@ -435,6 +435,18 @@ func _get_controller() -> Object:
             _cached_controller = singleton
             return _cached_controller
     return null
+
+func _join_strings(values: Variant, separator: String) -> String:
+    var combined := ""
+    var is_first := true
+    for value in values:
+        var segment := String(value)
+        if is_first:
+            combined = segment
+            is_first = false
+        else:
+            combined += "%s%s" % [separator, segment]
+    return combined
 
 func _is_object_valid(candidate: Object) -> bool:
     if candidate == null:

--- a/addons/platform_gui/panels/seeds/SeedsDashboardPanel.gd
+++ b/addons/platform_gui/panels/seeds/SeedsDashboardPanel.gd
@@ -125,7 +125,8 @@ func _refresh_streams(controller: Object) -> void:
         var source := mode if mode != "" else "unknown"
         stream_item.set_text(3, source)
         if data.has("path"):
-            stream_item.set_tooltip_text(0, "Router path: %s" % "::".join(data["path"]))
+            var path_segments := PackedStringArray(data.get("path", PackedStringArray()))
+            stream_item.set_tooltip_text(0, "Router path: %s" % _join_strings(path_segments, "::"))
             stream_item.set_tooltip_text(1, stream_item.get_tooltip_text(0))
             stream_item.set_tooltip_text(2, stream_item.get_tooltip_text(0))
         else:
@@ -149,14 +150,14 @@ func _refresh_routing(controller: Object) -> void:
         var stream := String(route.get("stream", ""))
         item.set_text(0, stream)
         var path: PackedStringArray = PackedStringArray(route.get("path", PackedStringArray()))
-        item.set_text(1, "::".join(path))
+        item.set_text(1, _join_strings(path, "::"))
         item.set_text(2, str(route.get("derived_seed", "")))
         item.set_text(3, str(route.get("resolved_seed", route.get("derived_seed", ""))))
         if route.has("notes"):
             item.set_tooltip_text(0, String(route["notes"]))
     var notes: Array = routing.get("notes", [])
     if notes.size() > 0:
-        var current := _status_label.bbcode_text
+        var current: String = _status_label.bbcode_text
         var error_tag := _ERROR_COLOR.to_html()
         if current == "" or current.find(error_tag) == -1:
             _status_label.bbcode_text = _format_status(String(notes[0]))
@@ -260,3 +261,13 @@ func _format_status(message: String, severity: String = "info") -> String:
         "error":
             color = _ERROR_COLOR
     return "[color=%s]%s %s[/color]" % [color.to_html(), icon, message]
+
+func _join_strings(values: PackedStringArray, separator: String) -> String:
+    var combined := ""
+    for index in range(values.size()):
+        var segment := String(values[index])
+        if index == 0:
+            combined = segment
+        else:
+            combined += "%s%s" % [separator, segment]
+    return combined

--- a/addons/platform_gui/services/strategy_metadata.gd
+++ b/addons/platform_gui/services/strategy_metadata.gd
@@ -432,17 +432,17 @@ func get_generator_error_hints(strategy_id: String) -> Dictionary:
     var entry: Dictionary = _metadata_cache[key]
     var hints: Dictionary = entry.get("error_hints", {})
     for hint_code in hints.keys():
-        var override := hints[hint_code]
+        var override_value: Variant = hints[hint_code]
         var base_entry: Dictionary = {}
         if merged.has(hint_code) and merged[hint_code] is Dictionary:
             base_entry = _duplicate_dictionary(merged[hint_code])
-        if override is Dictionary:
-            var override_dict: Dictionary = _duplicate_dictionary(override)
+        if override_value is Dictionary:
+            var override_dict: Dictionary = _duplicate_dictionary(override_value)
             for override_key in override_dict.keys():
                 base_entry[override_key] = override_dict[override_key]
             merged[hint_code] = base_entry
         else:
-            base_entry["message"] = String(override)
+            base_entry["message"] = String(override_value)
             if not merged.has(hint_code):
                 merged[hint_code] = base_entry
             else:
@@ -621,11 +621,11 @@ func _build_error_hints(required_keys: PackedStringArray, optional_key_types: Di
 func _duplicate_guidance_map(source: Dictionary) -> Dictionary:
     var clone: Dictionary = {}
     for key in source.keys():
-        var entry := source[key]
-        if entry is Dictionary:
-            clone[key] = _duplicate_dictionary(entry)
+        var entry_variant: Variant = source[key]
+        if entry_variant is Dictionary:
+            clone[key] = _duplicate_dictionary(entry_variant)
         else:
-            clone[key] = entry
+            clone[key] = entry_variant
     return clone
 
 func _duplicate_dictionary(value: Dictionary) -> Dictionary:
@@ -633,3 +633,10 @@ func _duplicate_dictionary(value: Dictionary) -> Dictionary:
     for key in value.keys():
         clone[key] = value[key]
     return clone
+
+func _is_object_valid(candidate: Object) -> bool:
+    if candidate == null:
+        return false
+    if candidate is Node:
+        return is_instance_valid(candidate)
+    return true

--- a/addons/platform_gui/workspaces/formulas/FormulasWorkspace.gd
+++ b/addons/platform_gui/workspaces/formulas/FormulasWorkspace.gd
@@ -432,7 +432,7 @@ func _inject_template_payload(steps: Array) -> void:
         return
     var template_config: Dictionary = template_variant
     for index in range(steps.size()):
-        var entry_variant := steps[index]
+        var entry_variant: Variant = steps[index]
         if typeof(entry_variant) != TYPE_DICTIONARY:
             continue
         var entry: Dictionary = entry_variant


### PR DESCRIPTION
## Summary
- ensure asynchronous QA runner hooks await `GDScriptFunctionState` results before inspecting payloads
- harden metadata service helpers with explicit variant typing and a shared object validity check
- update panel scripts to avoid unsupported `PackedStringArray` helpers by adding join utilities and type annotations compatible with Godot 4

## Testing
- ⚠️ `godot --headless --quit` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc763439508320b389b51cbdbd95b0