### PR TITLE
Fix syllable panel refresh binding and add main scroll

### DIFF
--- a/Main_Interface.tscn
+++ b/Main_Interface.tscn
@@ -34,97 +34,105 @@ script = ExtResource("16")
 [node name="StrategyMetadataService" type="Node" parent="."]
 script = ExtResource("3")
 
-[node name="MainLayout" type="VBoxContainer" parent="."]
+[node name="MainScrollContainer" type="ScrollContainer" parent="."]
 layout_mode = 2
 anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+horizontal_scroll_mode = 0
+vertical_scroll_mode = 1
+follow_focus = true
 
-[node name="DebugToolbar" parent="MainLayout" instance=ExtResource("4")]
+[node name="MainLayout" type="VBoxContainer" parent="MainScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DebugToolbar" parent="MainScrollContainer/MainLayout" instance=ExtResource("4")]
 unique_name_in_owner = true
 
-[node name="MainTabs" type="TabContainer" parent="MainLayout"]
+[node name="MainTabs" type="TabContainer" parent="MainScrollContainer/MainLayout"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 current_tab = 0
 
-[node name="Generators" type="VBoxContainer" parent="MainLayout/MainTabs"]
+[node name="Generators" type="VBoxContainer" parent="MainScrollContainer/MainLayout/MainTabs"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 metadata/_tab_index = 0
 
-[node name="GeneratorPanels" type="TabContainer" parent="MainLayout/MainTabs/Generators"]
+[node name="GeneratorPanels" type="TabContainer" parent="MainScrollContainer/MainLayout/MainTabs/Generators"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 current_tab = 0
 
-[node name="WordlistPanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("10")]
+[node name="WordlistPanel" parent="MainScrollContainer/MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("10")]
 unique_name_in_owner = true
 layout_mode = 2
 metadata/_tab_index = 0
 
-[node name="SyllableChainPanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("11")]
+[node name="SyllableChainPanel" parent="MainScrollContainer/MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("11")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 1
 
-[node name="TemplatePanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("12")]
+[node name="TemplatePanel" parent="MainScrollContainer/MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("12")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 2
 
-[node name="MarkovPanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("13")]
+[node name="MarkovPanel" parent="MainScrollContainer/MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("13")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 3
 
-[node name="HybridPipelinePanel" parent="MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("14")]
+[node name="HybridPipelinePanel" parent="MainScrollContainer/MainLayout/MainTabs/Generators/GeneratorPanels" instance=ExtResource("14")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 4
 
-[node name="SeedsDashboardPanel" parent="MainLayout/MainTabs" instance=ExtResource("5")]
+[node name="SeedsDashboardPanel" parent="MainScrollContainer/MainLayout/MainTabs" instance=ExtResource("5")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 1
 
-[node name="DebugLogPanel" parent="MainLayout/MainTabs" instance=ExtResource("6")]
+[node name="DebugLogPanel" parent="MainScrollContainer/MainLayout/MainTabs" instance=ExtResource("6")]
 unique_name_in_owner = true
 visible = false
 metadata/_tab_index = 2
 
-[node name="DatasetInspectorPanel" parent="MainLayout/MainTabs" instance=ExtResource("7")]
+[node name="DatasetInspectorPanel" parent="MainScrollContainer/MainLayout/MainTabs" instance=ExtResource("7")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 3
 
-[node name="QAPanel" parent="MainLayout/MainTabs" instance=ExtResource("8")]
+[node name="QAPanel" parent="MainScrollContainer/MainLayout/MainTabs" instance=ExtResource("8")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 metadata/_tab_index = 4
 
-[node name="FormulasWorkspace" parent="MainLayout/MainTabs" instance=ExtResource("9")]
+[node name="FormulasWorkspace" parent="MainScrollContainer/MainLayout/MainTabs" instance=ExtResource("9")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 5
 
-[node name="HelpersDock" type="VBoxContainer" parent="MainLayout/MainTabs"]
+[node name="HelpersDock" type="VBoxContainer" parent="MainScrollContainer/MainLayout/MainTabs"]
 unique_name_in_owner = true
 editor_description = "Placeholder dock reserved for future helper widgets. Attach new tools here to inherit middleware overrides automatically."
 visible = false

--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
@@ -21,6 +21,7 @@ var _require_middle_toggle: CheckButton= null
 var _middle_min_spin: SpinBox= null
 var _middle_max_spin: SpinBox= null
 var _min_length_spin: SpinBox= null
+var _refresh_button: Button = null
 var _regex_preset_container: VBoxContainer= null
 var _seed_edit: LineEdit= null
 var _preview_button: Button= null
@@ -84,6 +85,10 @@ func _ensure_nodes_ready() -> void:
 		_middle_max_spin = get_node("%MiddleMaxSpin") as SpinBox
 	if _min_length_spin == null:
 		_min_length_spin = get_node("%MinLengthSpin") as SpinBox
+	if _refresh_button == null:
+		_refresh_button = get_node_or_null("%RefreshButton") as Button
+		if _refresh_button == null:
+			_refresh_button = get_node_or_null("Header/RefreshButton") as Button
 	if _regex_preset_container == null:
 		_regex_preset_container = get_node("%RegexPresetContainer") as VBoxContainer
 	if _seed_edit == null:
@@ -100,8 +105,14 @@ func _ensure_nodes_ready() -> void:
 		_notes_label = get_node("%NotesLabel") as Label
 func _ready() -> void:
 	_ensure_nodes_ready()
-	_preview_button.pressed.connect(_on_preview_button_pressed)
-	%RefreshButton.pressed.connect(_on_refresh_pressed)
+	if _preview_button != null:
+		_preview_button.pressed.connect(_on_preview_button_pressed)
+	else:
+		push_warning("Preview button node missing; preview action disabled.")
+	if _refresh_button != null:
+		_refresh_button.pressed.connect(_on_refresh_pressed)
+	else:
+		push_warning("Refresh button node missing; automatic refresh disabled.")
 	_resource_list.item_selected.connect(_on_resource_selected)
 	_require_middle_toggle.toggled.connect(_on_require_middle_toggled)
 	_seed_edit.text_submitted.connect(_on_seed_submitted)
@@ -112,7 +123,6 @@ func _ready() -> void:
 	_refresh_metadata()
 	_refresh_resource_catalog()
 	_update_preview_state(null)
-
 func set_controller_override(controller: Object) -> void:
 	_ensure_nodes_ready()
 	_controller_override = controller

--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.tscn
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.tscn
@@ -22,6 +22,7 @@ text = "Syllable Chain Strategy"
 size_flags_horizontal = 3
 
 [node name="RefreshButton" type="Button" parent="Header"]
+unique_name_in_owner = true
 flat = true
 text = "Refresh"
 tooltip_text = "Reload strategy metadata and the resource catalogue."

--- a/tests/interface/test_main_interface_scene.gd
+++ b/tests/interface/test_main_interface_scene.gd
@@ -95,7 +95,9 @@ func _test_propagates_controller_and_metadata_overrides() -> Variant:
 
 func _test_exposes_expected_tabs() -> Variant:
     return _with_interface(func(interface: Control):
-        var main_tabs: TabContainer = interface.get_node("MainLayout/MainTabs") as TabContainer
+        var main_tabs: TabContainer = interface.get_node_or_null("MainScrollContainer/MainLayout/MainTabs") as TabContainer
+        if main_tabs == null:
+            main_tabs = interface.get_node_or_null("MainLayout/MainTabs") as TabContainer
         if main_tabs == null:
             return "MainTabs TabContainer should exist under the main layout."
         var visible_titles: Array[String] = []


### PR DESCRIPTION
## Summary
- guard the syllable chain panel's refresh hook by caching the button reference and warning when it is missing
- add a scroll container to the main interface layout so long generator panels remain reachable without altering the tab contents
- update the interface regression test to resolve the new scroll container path

## Testing
- godot4 --headless --path . --script res://tests/run_platform_gui_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cd4ed9dbb08320bb8e3402ee3e7be2