### PR TITLE
Fix focus style override for regex preset toggles

### DIFF
--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
@@ -211,7 +211,7 @@ func _build_regex_preset_controls() -> void:
 		button.text = String(preset.get("label", identifier.capitalize()))
 		button.tooltip_text = String(preset.get("description", ""))
 		button.focus_mode = Control.FOCUS_ALL
-		button.theme_override_styles["focus"] = FOCUS_STYLE
+		button.add_theme_style_override("focus", FOCUS_STYLE)
 		_regex_preset_container.add_child(button)
 		_regex_presets[identifier] = {
 			"definition": preset,


### PR DESCRIPTION
## Summary
- replace the deprecated theme_override_styles access in SyllableChainPanel with the Godot 4 add_theme_style_override helper to apply the focus highlight style

## Testing
- godot4 --headless --path . --script res://tests/run_generator_tests.gd
- godot4 --headless --path . --script res://tests/run_platform_gui_tests.gd
- godot4 --headless --path . --script res://tests/run_diagnostics_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cd5b8e3fb8832092128f28395a3106