### PR TITLE
Fix focus style override on regex preset checkboxes

### DIFF
--- a/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
+++ b/addons/platform_gui/panels/syllable_chain/SyllableChainPanel.gd
@@ -211,7 +211,7 @@ func _build_regex_preset_controls() -> void:
 		button.text = String(preset.get("label", identifier.capitalize()))
 		button.tooltip_text = String(preset.get("description", ""))
 		button.focus_mode = Control.FOCUS_ALL
-		button.add_theme_style_override("focus", FOCUS_STYLE)
+		button.add_theme_stylebox_override("focus", FOCUS_STYLE)
 		_regex_preset_container.add_child(button)
 		_regex_presets[identifier] = {
 			"definition": preset,


### PR DESCRIPTION
## Summary
- update the syllable chain panel to use Godot 4's stylebox override API for regex preset checkboxes so the focus highlight loads correctly

## Testing
- godot4 --headless --path . --script res://tests/run_platform_gui_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cd5e2a5cc8832093e05ac28f50edd7