### PR TITLE
Fix dataset inspector channel typing

### DIFF
--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
@@ -277,9 +277,13 @@ func _capture_messages(callable: Callable) -> Dictionary:
 
 func _capture_channels() -> Array[StringName]:
     _ensure_nodes_ready()
-    var channels := [STDERR_CHANNEL, STDOUT_CHANNEL]
-    channels.append_array(WARNING_CHANNELS)
-    channels.append_array(ERROR_CHANNELS)
+    var channels: Array[StringName] = []
+    channels.append(STDERR_CHANNEL)
+    channels.append(STDOUT_CHANNEL)
+    for warning_channel in WARNING_CHANNELS:
+        channels.append(warning_channel as StringName)
+    for error_channel in ERROR_CHANNELS:
+        channels.append(error_channel as StringName)
     return channels
 
 func _record_message(record: Dictionary, channel: StringName, message: String) -> void:


### PR DESCRIPTION
## Summary
- ensure the dataset inspector channel capture helper builds a typed Array[StringName]
- iterate through warning and error channel constants so message capture registration receives the expected types

## Testing
- godot4 --headless --path . --script res://tests/run_generator_tests.gd
- godot4 --headless --path . --script res://tests/run_platform_gui_tests.gd
- godot4 --headless --path . --script res://tests/run_diagnostics_tests.gd
- python tools/codex_preflight.py addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd --human --skip-manifest

------
https://chatgpt.com/codex/tasks/task_e_68cd7104ad208320825339c441dfdef4