### PR TITLE
Fix dataset inspector channel typing and refresh controller

### DIFF
--- a/Main_Interface.gd
+++ b/Main_Interface.gd
@@ -45,6 +45,9 @@ func _ready() -> void:
 	if is_instance_valid(_metadata_service) and _metadata_service.has_method("set_controller_override"):
 		_metadata_service.call("set_controller_override", _controller)
 
+	if is_instance_valid(_controller) and _controller.has_method("refresh_connections"):
+		_controller.call("refresh_connections")
+
 	for consumer in _middleware_consumers:
 		if consumer == null:
 			continue

--- a/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
+++ b/addons/platform_gui/panels/datasets/DatasetInspectorPanel.gd
@@ -13,12 +13,12 @@ extends VBoxContainer
 
 const STDOUT_CHANNEL := StringName("stdout")
 const STDERR_CHANNEL := StringName("stderr")
-const WARNING_CHANNELS := [
+const WARNING_CHANNELS: Array[StringName] = [
     StringName("warning"),
     StringName("user_warning"),
     StringName("script_warning"),
 ]
-const ERROR_CHANNELS := [
+const ERROR_CHANNELS: Array[StringName] = [
     StringName("error"),
     StringName("user_error"),
     StringName("script_error"),


### PR DESCRIPTION
## Summary
- type the dataset inspector channel constants and collections so message capture returns the expected StringName arrays
- refresh the RNGProcessorController connections after the Main Interface injects overrides to keep the middleware available to generator panels

## Testing
- `godot4 --headless --path . --script res://tests/run_platform_gui_tests.gd`


------
https://chatgpt.com/codex/tasks/task_e_68cd73d087b083209db1ef75637e1913