### PR TITLE
Fix Debug Log panel visibility

### DIFF
--- a/addons/platform_gui/panels/logs/DebugLogPanel.tscn
+++ b/addons/platform_gui/panels/logs/DebugLogPanel.tscn
@@ -49,6 +49,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 320)
 script = ExtResource("3_compat")
 bbcode_enabled = true
 scroll_active = true


### PR DESCRIPTION
## Summary
- ensure the Debug Log panel's rich text log display reserves vertical space so recorded DebugRNG entries remain visible

## Testing
- godot4 --headless --path . --script tests/run_platform_gui_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cd856e44f88320b956412598eb5397