### PR TITLE
Fix hybrid panel deselection signal handler

### DIFF
--- a/addons/platform_gui/panels/hybrid/HybridPipelinePanel.gd
+++ b/addons/platform_gui/panels/hybrid/HybridPipelinePanel.gd
@@ -344,7 +344,7 @@ func _on_step_selected(index: int) -> void:
     _update_step_details(step)
     _highlight_active_step(step)
 
-func _on_step_deselected() -> void:
+func _on_step_deselected(_position: Vector2 = Vector2.ZERO, _mouse_button_index: int = 0) -> void:
     _ensure_nodes_ready()
     _update_step_details(null)
     _highlight_active_step(null)


### PR DESCRIPTION
## Summary
- update the HybridPipelinePanel empty list click handler to accept the ItemList signal arguments so deselection no longer triggers runtime errors

## Testing
- godot4 --headless --path . --script res://tests/run_generator_tests.gd
- godot4 --headless --path . --script res://tests/run_platform_gui_tests.gd
- godot4 --headless --path . --script res://tests/run_diagnostics_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cd89ece028832089ca24b6a56abfbf