### PR TITLE
Add dataset resource templates and update Markov example

### DIFF
--- a/data/factions/factREADME.md
+++ b/data/factions/factREADME.md
@@ -21,6 +21,23 @@ Maintain each category as a dedicated Godot Resource (`.tres` or `.res`) or comp
 
 Document any bespoke conversion steps alongside the script you used so future updates can replicate the pipeline.
 
+## Ready-to-clone templates
+
+The `data/factions/templates/` directory ships with example `.tres` files for
+each resource type discussed above:
+
+- `faction_wordlist_template.tres` illustrates how to populate a
+  `WordListResource` with ideology terms and weighting metadata.
+- `faction_syllable_template.tres` demonstrates a lightweight
+  `SyllableSetResource` that mixes optional middle syllables.
+- `faction_markov_template.tres` captures a minimal
+  `MarkovModelResource` wired for the modern `states` + `start_tokens` layout
+  required by `MarkovModelResource.gd`.
+
+Duplicate these assets, rename them to match your content, and then swap the
+example entries for your curated vocabulary before wiring the resource into a
+strategy.
+
 ## Hybrid and template patterns
 
 Faction titles typically combine the three vocabularies using either hybrid chaining or templated substitution:

--- a/data/factions/templates/faction_markov_template.tres
+++ b/data/factions/templates/faction_markov_template.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("ar", "val", "syn", "or", "um", "dral", "ion")
+start_tokens = [{"token": "ar", "weight": 1.0}, {"token": "val", "weight": 1.0}, {"token": "syn", "weight": 0.8}, {"token": "or", "weight": 0.6}]
+transitions = {
+"ar": [{"token": "dral", "weight": 1.0}],
+"val": [{"token": "ion", "weight": 1.0}],
+"syn": [{"token": "dral", "weight": 0.6}, {"token": "ion", "weight": 0.4}],
+"or": [{"token": "um", "weight": 1.0}],
+"um": [{"token": "<END>", "weight": 1.0}],
+"dral": [{"token": "<END>", "weight": 1.0}],
+"ion": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+notes = "Faction title stem model showcasing minimal state and transition definitions."

--- a/data/factions/templates/faction_syllable_template.tres
+++ b/data/factions/templates/faction_syllable_template.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Ar", "Val", "Syn", "Or")
+middles = PackedStringArray("ca", "di", "le")
+suffixes = PackedStringArray("rum", "dral", "ion")
+allow_empty_middle = true

--- a/data/factions/templates/faction_wordlist_template.tres
+++ b/data/factions/templates/faction_wordlist_template.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Verdant Accord", "Iron Will", "Celestial Concord", "Shadow Treaty")
+weighted_entries = [{"value": "Verdant Accord", "weight": 1.0}, {"value": "Iron Will", "weight": 1.25}, {"value": "Celestial Concord", "weight": 0.8}, {"value": "Shadow Treaty", "weight": 0.6}]

--- a/data/markov_models/arcane_elven_markov.tres
+++ b/data/markov_models/arcane_elven_markov.tres
@@ -1,21 +1,38 @@
-[gd_resource type="Resource" script_class_name="MarkovModelResource" load_steps=2]
+[gd_resource type="Resource" load_steps=2 format=3]
 
-[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1_0"]
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
 
 [resource]
+script = ExtResource("1")
 order = 2
-start_sequences = PackedStringArray("ae", "el", "li")
+states = PackedStringArray("ae", "el", "er", "la", "li", "ly", "ar", "an", "ia", "is", "ra", "ri", "ry", "in", "na", "ny", "ya", "ys")
+start_tokens = [
+    {"token": "ae", "weight": 0.4},
+    {"token": "el", "weight": 0.35},
+    {"token": "li", "weight": 0.25}
+]
 transitions = {
-"ae": {"l": 0.6, "r": 0.4},
-"el": {"a": 0.5, "i": 0.3, "y": 0.2},
-"la": {"r": 0.5, "n": 0.5},
-"li": {"a": 0.6, "s": 0.4},
-"ar": {"a": 0.2, "i": 0.3, "y": 0.5},
-"ri": {"n": 0.6, "s": 0.4},
-"in": {"a": 0.4, "y": 0.6},
-"ny": {"a": 0.7, "s": 0.3},
-"ya": {"n": 0.6, "r": 0.4}
+"ae": [{"token": "el", "weight": 0.6}, {"token": "er", "weight": 0.4}],
+"el": [{"token": "la", "weight": 0.5}, {"token": "li", "weight": 0.3}, {"token": "ly", "weight": 0.2}],
+"la": [{"token": "ar", "weight": 0.5}, {"token": "an", "weight": 0.5}],
+"li": [{"token": "ia", "weight": 0.6}, {"token": "is", "weight": 0.4}],
+"ar": [{"token": "ra", "weight": 0.2}, {"token": "ri", "weight": 0.3}, {"token": "ry", "weight": 0.5}],
+"ri": [{"token": "in", "weight": 0.6}, {"token": "is", "weight": 0.4}],
+"in": [{"token": "na", "weight": 0.4}, {"token": "ny", "weight": 0.6}],
+"ny": [{"token": "ya", "weight": 0.7}, {"token": "ys", "weight": 0.3}],
+"ya": [{"token": "an", "weight": 0.6}, {"token": "ar", "weight": 0.4}],
+"er": [{"token": "<END>", "weight": 1.0}],
+"ly": [{"token": "<END>", "weight": 1.0}],
+"an": [{"token": "<END>", "weight": 1.0}],
+"ia": [{"token": "<END>", "weight": 1.0}],
+"is": [{"token": "<END>", "weight": 1.0}],
+"ra": [{"token": "<END>", "weight": 1.0}],
+"ry": [{"token": "<END>", "weight": 1.0}],
+"na": [{"token": "<END>", "weight": 1.0}],
+"ys": [{"token": "<END>", "weight": 1.0}]
 }
+end_tokens = PackedStringArray("<END>")
+default_temperature = 0.95
 locale = "Aelorian Enclaves"
 domain = "Arcane Highborn"
-rarity_notes = "Used for venerable spellcasters who have earned archival status within the enclave registries. Names from this model should surface sparingly in procedural content."
+notes = "Used for venerable spellcasters who have earned archival status within the enclave registries. Names from this model should surface sparingly in procedural content."

--- a/data/monsters/monsREADME.md
+++ b/data/monsters/monsREADME.md
@@ -12,6 +12,10 @@ Provide `WordListResource` assets that catalogue:
 - **Textures and materials** – Skin, scale, fur, and exoskeleton descriptors, including colours and surface qualities.
 - **Anatomical modifiers** – Horn configurations, wing structures, tail types, sensory organs, and elemental infusions.
 
+Ready-made examples live under `data/monsters/templates/`. Copy the
+`monster_wordlist_template.tres` file to bootstrap a new list with weighting
+metadata already in place.
+
 Keep each list scoped to a single concept so Hybrid templates can mix and match descriptors without duplicating data. When curating entries, stick to lowercase tokens; Template and Hybrid strategies can capitalise or stylise as needed.
 
 ### Behaviour lexicon
@@ -27,12 +31,19 @@ Author complementary `WordListResource` files that describe behaviours, combat s
 3. In the Godot editor, create a new `SyllableSetResource` and paste the syllables into the exported arrays (prefix/mid/suffix). Group guttural, hissing, or shrieking patterns into separate resources when the species exhibits multiple vocal registers.
 4. Save the `.tres` files under `data/syllable_sets/monsters/` and reference them from this folder's documentation or Hybrid configs.
 
+The `monster_syllable_template.tres` example inside `data/monsters/templates/`
+shows a curated prefix/middle/suffix split you can duplicate for new species.
+
 ### Markov models
 
 1. Build a source list of canonical monster cries or name stems (game lore, tabletop bestiaries, audio transcripts).
 2. Normalise spellings so similar phonemes share the same characters—Markov quality depends on consistent tokens.
 3. Train a `MarkovModelResource` using the workflow in [`DevDoc.txt`](../../DevDoc.txt) Chapter 7 (Markov Chains). Export the resulting `.tres` into `data/markov_models/monsters/` and annotate its intent in this folder.
 4. Record the training corpus and parameters in a sibling Markdown file so QA can reproduce the model.
+
+For quick experiments, duplicate `monster_markov_template.tres` from
+`data/monsters/templates/`. It already follows the `states`/`start_tokens`
+layout required by the current `MarkovModelResource` implementation.
 
 ## Hybrid strategy examples
 

--- a/data/monsters/templates/monster_markov_template.tres
+++ b/data/monsters/templates/monster_markov_template.tres
@@ -1,0 +1,22 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("kra", "ghul", "ith", "vor", "nak", "gash", "ithk", "lur")
+start_tokens = [{"token": "kra", "weight": 1.0}, {"token": "ghul", "weight": 0.9}, {"token": "ith", "weight": 0.8}, {"token": "vor", "weight": 0.7}]
+transitions = {
+"kra": [{"token": "nak", "weight": 1.0}],
+"ghul": [{"token": "gash", "weight": 1.0}],
+"ith": [{"token": "lur", "weight": 1.0}],
+"vor": [{"token": "ithk", "weight": 1.0}],
+"nak": [{"token": "<END>", "weight": 1.0}],
+"gash": [{"token": "<END>", "weight": 1.0}],
+"lur": [{"token": "<END>", "weight": 1.0}],
+"ithk": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+notes = "Monster vocalisation model emphasising guttural syllable closures."

--- a/data/monsters/templates/monster_syllable_template.tres
+++ b/data/monsters/templates/monster_syllable_template.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Kra", "Ghul", "Ith", "Vor")
+middles = PackedStringArray("za", "lur", "thra")
+suffixes = PackedStringArray("nak", "gash", "ith")
+allow_empty_middle = false

--- a/data/monsters/templates/monster_wordlist_template.tres
+++ b/data/monsters/templates/monster_wordlist_template.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("chitin-plated", "ember-hearted", "void-winged", "dune-stalker")
+weighted_entries = [{"value": "chitin-plated", "weight": 1.2}, {"value": "ember-hearted", "weight": 1.0}, {"value": "void-winged", "weight": 0.9}, {"value": "dune-stalker", "weight": 1.1}]

--- a/data/objects/itemREADME.md
+++ b/data/objects/itemREADME.md
@@ -34,6 +34,21 @@ This folder holds themed vocabularies for equipment, curios, relics, and other i
 - **Hybrid pipelines** (`steps` + optional `template`) shine when the name depends on staged decisions or needs interpolation from multiple sources (e.g. pick material → select item type → slot in an effect to yield "Auric Glaive of Drowning"). Use them for multi-sentence blurbs or when data must be reused later in the generation process.
 - For sentence-style or paragraph outputs, use the `template` key available to both TemplateStrategy and HybridStrategy. It provides full-string control ("Forged from $material, this $item_core hums with $effect"), keeping formatting consistent across locales.
 
+## Starter templates
+
+Reference the assets in `data/objects/templates/` when you need an immediate
+resource scaffold:
+
+- `object_wordlist_template.tres` stores a small equipment-flavoured
+  `WordListResource` with weighted entries.
+- `object_syllable_template.tres` shows how to distribute fragments across the
+  `SyllableSetResource` arrays while keeping the middle optional.
+- `object_markov_template.tres` is a `MarkovModelResource` configured with the
+  modern transition layout so new models can plug directly into the generator.
+
+Copy the relevant template, rename it, and replace the placeholder entries with
+your item vocabulary before committing the resource.
+
 ## Quality assurance checklist
 - Run the dataset inspector to confirm new `.tres` resources appear with the expected entry counts:
   ```

--- a/data/objects/templates/object_markov_template.tres
+++ b/data/objects/templates/object_markov_template.tres
@@ -1,0 +1,24 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("aur", "ic", "obs", "idian", "whis", "pering", "gla", "ive", "coil", "lens")
+start_tokens = [{"token": "aur", "weight": 1.0}, {"token": "obs", "weight": 1.0}, {"token": "whis", "weight": 0.8}, {"token": "gla", "weight": 0.6}]
+transitions = {
+"aur": [{"token": "ic", "weight": 1.0}],
+"obs": [{"token": "idian", "weight": 1.0}],
+"whis": [{"token": "pering", "weight": 1.0}],
+"gla": [{"token": "ive", "weight": 1.0}],
+"ic": [{"token": "<END>", "weight": 1.0}],
+"idian": [{"token": "<END>", "weight": 1.0}],
+"pering": [{"token": "<END>", "weight": 1.0}],
+"coil": [{"token": "<END>", "weight": 1.0}],
+"lens": [{"token": "<END>", "weight": 1.0}],
+"ive": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+notes = "Object naming Markov template showing how multi-token outputs terminate."

--- a/data/objects/templates/object_syllable_template.tres
+++ b/data/objects/templates/object_syllable_template.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Or", "Gla", "Ob", "Whis")
+middles = PackedStringArray("bi", "per", "sid")
+suffixes = PackedStringArray("ion", "dra", "coil")
+allow_empty_middle = true

--- a/data/objects/templates/object_wordlist_template.tres
+++ b/data/objects/templates/object_wordlist_template.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Auric Glaive", "Shattered Relic", "Obsidian Lens", "Whispering Coil")
+weighted_entries = [{"value": "Auric Glaive", "weight": 1.0}, {"value": "Shattered Relic", "weight": 0.8}, {"value": "Obsidian Lens", "weight": 1.2}, {"value": "Whispering Coil", "weight": 0.9}]

--- a/data/people/peopleREADME.md
+++ b/data/people/peopleREADME.md
@@ -99,6 +99,22 @@ Consume the model with the Markov strategy:
 }
 ```
 
+## Starter templates
+
+Clone the example resources in `data/people/templates/` whenever you need a
+baseline asset that already targets the expected resource type:
+
+- `people_wordlist_template.tres` – A `WordListResource` populated with a
+  handful of balanced given names and example weights.
+- `people_syllable_template.tres` – A `SyllableSetResource` that shows how to
+  split prefixes, middles, and suffixes for hybrid syllable strategies.
+- `people_markov_template.tres` – A `MarkovModelResource` configured with
+  explicit `states`, `start_tokens`, and transition weights compatible with the
+  modern Markov strategy implementation.
+
+Duplicate a template, rename it to match your dataset, and replace the sample
+values with your curated lists before committing the new resource.
+
 ## When to chain datasets with Hybrid configs
 
 Use `HybridStrategy` whenever a character concept spans multiple datasets or

--- a/data/people/templates/people_markov_template.tres
+++ b/data/people/templates/people_markov_template.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("al", "cor", "ma", "tha", "en", "is", "on", "ris", "len")
+start_tokens = [{"token": "al", "weight": 1.0}, {"token": "cor", "weight": 1.0}, {"token": "ma", "weight": 0.75}, {"token": "tha", "weight": 0.5}]
+transitions = {
+"al": [{"token": "en", "weight": 1.0}],
+"cor": [{"token": "is", "weight": 0.5}, {"token": "on", "weight": 0.5}],
+"ma": [{"token": "ris", "weight": 1.0}],
+"tha": [{"token": "len", "weight": 1.0}],
+"en": [{"token": "<END>", "weight": 1.0}],
+"is": [{"token": "<END>", "weight": 1.0}],
+"on": [{"token": "<END>", "weight": 1.0}],
+"ris": [{"token": "<END>", "weight": 1.0}],
+"len": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+notes = "Template Markov chain for people names showing token weighting and termination entries."

--- a/data/people/templates/people_syllable_template.tres
+++ b/data/people/templates/people_syllable_template.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Al", "Cor", "Ma", "Tha")
+middles = PackedStringArray("ve", "ri", "le")
+suffixes = PackedStringArray("en", "is", "on")
+allow_empty_middle = false

--- a/data/people/templates/people_wordlist_template.tres
+++ b/data/people/templates/people_wordlist_template.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Aveline", "Corin", "Maris", "Thalen")
+weighted_entries = [{"value": "Aveline", "weight": 1.5}, {"value": "Corin", "weight": 1.0}, {"value": "Maris", "weight": 1.0}, {"value": "Thalen", "weight": 0.75}]

--- a/data/places/placesREADME.md
+++ b/data/places/placesREADME.md
@@ -10,6 +10,22 @@ This folder aggregates the resources required to assemble location names. Organi
 
 Store datasets as Godot `.tres` resources (or compatible formats) so they load through the existing data pipeline. Keep filenames descriptive—`temperate_biomes.tres` communicates intent better than a numeric ID and helps when debugging failed lookups.
 
+## Ready-to-use templates
+
+The `data/places/templates/` folder provides example resources that adhere to
+the structure described above:
+
+- `place_wordlist_template.tres` – `WordListResource` with balanced descriptor
+  and biome phrases.
+- `place_syllable_template.tres` – `SyllableSetResource` configured with
+  optional middle fragments to demonstrate compound place roots.
+- `place_markov_template.tres` – `MarkovModelResource` prepared with explicit
+  states, start tokens, and weighted transitions compatible with the current
+  generator runtime.
+
+Copy and rename a template when you need a quick starting point, then replace
+the placeholder entries with your curated data.
+
 ## Composing place names
 
 Several generation strategies can reference the datasets in this folder. The examples below mirror the configuration dictionaries passed to `NameGenerator.generate`.

--- a/data/places/templates/place_markov_template.tres
+++ b/data/places/templates/place_markov_template.tres
@@ -1,0 +1,25 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("storm", "sun", "cry", "mar", "reach", "ken", "stal", "shrou", "mere", "fell", "hold")
+start_tokens = [{"token": "storm", "weight": 1.0}, {"token": "sun", "weight": 0.8}, {"token": "cry", "weight": 0.9}, {"token": "mar", "weight": 0.7}]
+transitions = {
+"storm": [{"token": "reach", "weight": 1.0}],
+"sun": [{"token": "ken", "weight": 1.0}],
+"cry": [{"token": "stal", "weight": 1.0}],
+"mar": [{"token": "shrou", "weight": 1.0}],
+"reach": [{"token": "<END>", "weight": 0.5}, {"token": "mere", "weight": 0.5}],
+"ken": [{"token": "fell", "weight": 1.0}],
+"stal": [{"token": "hold", "weight": 1.0}],
+"shrou": [{"token": "fell", "weight": 1.0}],
+"mere": [{"token": "<END>", "weight": 1.0}],
+"fell": [{"token": "<END>", "weight": 1.0}],
+"hold": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+notes = "Place name model that chains root fragments with optional suffix transitions."

--- a/data/places/templates/place_syllable_template.tres
+++ b/data/places/templates/place_syllable_template.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Storm", "Sun", "Cry", "Mar")
+middles = PackedStringArray("reach", "ken", "stal", "shrou")
+suffixes = PackedStringArray("helm", "mere", "hold", "fell")
+allow_empty_middle = true

--- a/data/places/templates/place_wordlist_template.tres
+++ b/data/places/templates/place_wordlist_template.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Shrouded Marsh", "Sunken Archipelago", "Crystal Range", "Stormreach Expanse")
+weighted_entries = [{"value": "Shrouded Marsh", "weight": 1.0}, {"value": "Sunken Archipelago", "weight": 0.7}, {"value": "Crystal Range", "weight": 1.2}, {"value": "Stormreach Expanse", "weight": 0.9}]

--- a/data/skills_powers/skilREADME.md
+++ b/data/skills_powers/skilREADME.md
@@ -12,6 +12,16 @@ Populate the directory with the following resource files:
 
 Name files descriptively (for example `action_verbs.tres`, `elemental_themes.tres`, and `suffixes.tres`) so downstream configs remain self-documenting.
 
+The `data/skills_powers/templates/` folder includes starter resources you can
+copy when assembling new datasets:
+
+- `skill_wordlist_template.tres` demonstrates a verb-focused
+  `WordListResource` with weighted entries.
+- `skill_syllable_template.tres` offers a prewired `SyllableSetResource` for
+  suffix construction.
+- `skill_markov_template.tres` provides a compliant `MarkovModelResource`
+  showing the modern transition block format.
+
 ## Conversion & verification workflow
 
 1. Collect raw terms in a plain-text or CSV scratch file.

--- a/data/skills_powers/templates/skill_markov_template.tres
+++ b/data/skills_powers/templates/skill_markov_template.tres
@@ -1,0 +1,25 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("py", "ro", "ae", "ther", "um", "bra", "lum", "ina", "burst", "ward", "form")
+start_tokens = [{"token": "py", "weight": 1.0}, {"token": "ae", "weight": 0.8}, {"token": "um", "weight": 0.7}, {"token": "lum", "weight": 0.6}]
+transitions = {
+"py": [{"token": "ro", "weight": 1.0}],
+"ae": [{"token": "ther", "weight": 1.0}],
+"um": [{"token": "bra", "weight": 1.0}],
+"lum": [{"token": "ina", "weight": 1.0}],
+"ro": [{"token": "burst", "weight": 1.0}],
+"ther": [{"token": "ward", "weight": 1.0}],
+"bra": [{"token": "form", "weight": 1.0}],
+"ina": [{"token": "ward", "weight": 1.0}],
+"burst": [{"token": "<END>", "weight": 1.0}],
+"ward": [{"token": "<END>", "weight": 1.0}],
+"form": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+notes = "Skill naming chain that maps prefix syllables to themed suffix payloads."

--- a/data/skills_powers/templates/skill_syllable_template.tres
+++ b/data/skills_powers/templates/skill_syllable_template.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Py", "Ae", "Um", "Lum")
+middles = PackedStringArray("ro", "ther", "bra")
+suffixes = PackedStringArray("burst", "ward", "form")
+allow_empty_middle = true

--- a/data/skills_powers/templates/skill_wordlist_template.tres
+++ b/data/skills_powers/templates/skill_wordlist_template.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Cleave", "Ward", "Entwine", "Surge")
+weighted_entries = [{"value": "Cleave", "weight": 1.0}, {"value": "Ward", "weight": 1.2}, {"value": "Entwine", "weight": 0.8}, {"value": "Surge", "weight": 1.1}]


### PR DESCRIPTION
## Summary
- add ready-to-clone word list, syllable, and Markov template resources for each major dataset category
- refresh dataset documentation to point contributors at the new templates and explain how to reuse them
- migrate the bundled arcane elven Markov resource to the current states/start token transition format

## Testing
- not run (godot binary unavailable in container): `godot --headless --path . --script res://tests/run_generator_tests.gd`
- not run (godot binary unavailable in container): `godot --headless --path . --script res://tests/run_diagnostics_tests.gd`

------
https://chatgpt.com/codex/tasks/task_e_68cd949720748320abcdd8856775fda1