### PR TITLE
Add starter people and faction dataset resources

### DIFF
--- a/data/factions/factREADME.md
+++ b/data/factions/factREADME.md
@@ -10,7 +10,7 @@ Author the faction dataset as three parallel resource lists so hybrid strategies
 - **Structure nouns** – Collective nouns that describe the organisation type (e.g. "Order", "Syndicate", "League"). Use singular forms to avoid subject-verb agreement issues when the template adds pluralisation.
 - **Location modifiers** – Geographic or cosmological anchors (e.g. "of the Sapphire Coast", "from Orion", "of Western Reach"). Store the leading preposition if one is required so templates can reuse the phrase verbatim.
 
-Maintain each category as a dedicated Godot Resource (`.tres` or `.res`) or compatible JSON/CSV surrogate that the data conversion step can ingest. Align resource naming with the category (for example, `ideology_terms.tres`).
+Maintain each category as a dedicated Godot Resource (`.tres` or `.res`) or compatible JSON/CSV surrogate that the data conversion step can ingest. Align resource naming with the category (for example, `ideology_terms.tres`). This repository now includes `ideology_terms.tres`, `structure_nouns.tres`, and `location_modifiers.tres` under `data/factions/` so designers have ready-to-wire exemplars for each bucket.
 
 ## Resource conversion workflow
 

--- a/data/factions/ideology_terms.tres
+++ b/data/factions/ideology_terms.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Azure Concord", "Iron Will", "Verdant Accord", "Silent Aegis", "Starward Promise")
+weighted_entries = [{"value": "Azure Concord", "weight": 1.0}, {"value": "Iron Will", "weight": 1.2}, {"value": "Verdant Accord", "weight": 1.1}, {"value": "Silent Aegis", "weight": 0.9}, {"value": "Starward Promise", "weight": 0.8}]
+locale = "en"
+domain = "factions"

--- a/data/factions/location_modifiers.tres
+++ b/data/factions/location_modifiers.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("of the Sapphire Coast", "from Orion", "of Western Reach", "of the Gilded Expanse", "from the Ashen Depths")
+weighted_entries = [{"value": "of the Sapphire Coast", "weight": 1.0}, {"value": "from Orion", "weight": 0.9}, {"value": "of Western Reach", "weight": 1.1}, {"value": "of the Gilded Expanse", "weight": 0.85}, {"value": "from the Ashen Depths", "weight": 0.95}]
+locale = "en"
+domain = "factions"

--- a/data/factions/structure_nouns.tres
+++ b/data/factions/structure_nouns.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Order", "Consortium", "League", "Collective", "Compact")
+weighted_entries = [{"value": "Order", "weight": 1.0}, {"value": "Consortium", "weight": 0.9}, {"value": "League", "weight": 1.1}, {"value": "Collective", "weight": 0.95}, {"value": "Compact", "weight": 0.85}]
+locale = "en"
+domain = "factions"

--- a/data/people/markov_models/people_template_dwarven_markov.tres
+++ b/data/people/markov_models/people_template_dwarven_markov.tres
@@ -1,0 +1,24 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 2
+states = PackedStringArray("ba", "ld", "or", "in", "gar", "dok", "thor", "grim", "<END>")
+start_tokens = [{"token": "ba", "weight": 1.0}, {"token": "gar", "weight": 0.8}, {"token": "thor", "weight": 0.6}]
+transitions = {
+"ba": [{"token": "ld", "weight": 1.0}],
+"ld": [{"token": "or", "weight": 0.7}, {"token": "in", "weight": 0.3}],
+"or": [{"token": "<END>", "weight": 0.5}, {"token": "grim", "weight": 0.5}],
+"in": [{"token": "dok", "weight": 0.6}, {"token": "<END>", "weight": 0.4}],
+"gar": [{"token": "dok", "weight": 1.0}],
+"dok": [{"token": "<END>", "weight": 1.0}],
+"thor": [{"token": "grim", "weight": 1.0}],
+"grim": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+locale = "dwarven"
+domain = "people"
+notes = "Seed Markov chain demonstrating dwarven-flavoured name construction."

--- a/data/people/peopleREADME.md
+++ b/data/people/peopleREADME.md
@@ -34,9 +34,10 @@ and strategies share the same inputs.
 2. Right-click inside `res://data/wordlists/people/` and choose **New Resource…**.
 3. Search for `WordListResource` and create a new `.tres` file (e.g.
    `given_names_en_female.tres`).
-4. Paste your list into the `words` array in the Inspector, preserving one entry
-   per element. Use the **Sort** button to keep ordering deterministic when
-   weights are not supplied.
+4. Paste your list into the `entries` array in the Inspector, preserving one
+   entry per element. Use the optional `weighted_entries` helper if you need to
+   bias selection, or rely on the **Sort** button to keep ordering deterministic
+   when weights are not supplied.
 5. Commit the `.tres` file alongside a short changelog entry describing the
    source and any filters applied.
 
@@ -102,13 +103,20 @@ Consume the model with the Markov strategy:
 ## Starter templates
 
 Clone the example resources in `data/people/templates/` whenever you need a
-baseline asset that already targets the expected resource type:
+baseline asset that already targets the expected resource type. The
+`data/people/wordlists/`, `data/people/syllable_sets/`, and
+`data/people/markov_models/` directories now ship with matching starter assets
+so you can wire a complete dataset into a strategy without building everything
+from scratch:
 
-- `people_wordlist_template.tres` – A `WordListResource` populated with a
-  handful of balanced given names and example weights.
-- `people_syllable_template.tres` – A `SyllableSetResource` that shows how to
+- `people_wordlist_template.tres` / `people_template_given_names.tres` – Sample
+  `WordListResource` files populated with balanced given names and matching
+  weights.
+- `people_syllable_template.tres` /
+  `people_template_clan_syllables.tres` – `SyllableSetResource` examples that
   split prefixes, middles, and suffixes for hybrid syllable strategies.
-- `people_markov_template.tres` – A `MarkovModelResource` configured with
+- `people_markov_template.tres` /
+  `people_template_dwarven_markov.tres` – `MarkovModelResource` examples with
   explicit `states`, `start_tokens`, and transition weights compatible with the
   modern Markov strategy implementation.
 

--- a/data/people/syllable_sets/people_template_clan_syllables.tres
+++ b/data/people/syllable_sets/people_template_clan_syllables.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("Bal", "Dor", "Fen", "Gar")
+middles = PackedStringArray("ri", "un", "al")
+suffixes = PackedStringArray("d", "in", "or", "ul")
+allow_empty_middle = false
+locale = "dwarven"
+domain = "people"

--- a/data/people/wordlists/people_template_given_names.tres
+++ b/data/people/wordlists/people_template_given_names.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Aveline", "Corin", "Maris", "Thalen", "Eryndor", "Selise")
+weighted_entries = [{"value": "Aveline", "weight": 1.5}, {"value": "Corin", "weight": 1.0}, {"value": "Maris", "weight": 1.0}, {"value": "Thalen", "weight": 0.8}, {"value": "Eryndor", "weight": 0.9}, {"value": "Selise", "weight": 1.2}]
+locale = "en"
+domain = "people"


### PR DESCRIPTION
## Summary
- add ready-to-use people dataset resources that demonstrate word lists, syllable sets, and a Markov model
- refresh the people dataset README to reference the exported entries array and point to the new starter assets
- seed the faction dataset with ideology, structure, and location vocabularies and document their availability

## Testing
- `godot --headless --path . --script tests/run_generator_tests.gd` *(fails: `godot`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd966a3b8c8320a814b0f4823a5bc8