### PR TITLE
Add weapon wordlist templates for objects dataset

### DIFF
--- a/data/objects/itemREADME.md
+++ b/data/objects/itemREADME.md
@@ -49,6 +49,13 @@ resource scaffold:
 Copy the relevant template, rename it, and replace the placeholder entries with
 your item vocabulary before committing the resource.
 
+| Template filename | Contents | Reuse guidance |
+| --- | --- | --- |
+| `weapon_materials_template.tres` | Weighted sample of mundane through legendary alloys (steel, meteoric iron, obsidian, starfire alloy). | Start with TemplateStrategy for quick `$modifier $material $weapon_core` pairings; HybridStrategy can reference it in a `steps` chain when branching into effect-driven loot. |
+| `weapon_modifiers_template.tres` | Uniform list of tonal adjectives (keen, ancient, ceremonial, whispering). | Works as-is for TemplateStrategy slots; reuse in Hybrid setups when combining with conditional templates or follow-up effect picks. |
+| `weapon_cores_template.tres` | Uniform base noun list (blade, spear, glaive, scythe). | Ideal for both TemplateStrategy and HybridStrategy as the structural noun anchor before embellishments. |
+| `weapon_effects_template.tres` | Uniform suffix phrases (of embers, of echoes, of tides, of dawns). | Drop directly into TemplateStrategy endings or pull in during Hybrid finalisation steps when effects depend on earlier choices. |
+
 ## Quality assurance checklist
 - Run the dataset inspector to confirm new `.tres` resources appear with the expected entry counts:
   ```

--- a/data/objects/weapon_cores_template.tres
+++ b/data/objects/weapon_cores_template.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("Blade", "Spear", "Glaive", "Scythe")

--- a/data/objects/weapon_effects_template.tres
+++ b/data/objects/weapon_effects_template.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("of Embers", "of Echoes", "of Tides", "of Dawns")

--- a/data/objects/weapon_materials_template.tres
+++ b/data/objects/weapon_materials_template.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+weighted_entries = [{"value": "Steel", "weight": 5.0}, {"value": "Meteoric Iron", "weight": 2.0}, {"value": "Obsidian", "weight": 1.0}, {"value": "Starfire Alloy", "weight": 0.5}]

--- a/data/objects/weapon_modifiers_template.tres
+++ b/data/objects/weapon_modifiers_template.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray("Keen", "Ancient", "Ceremonial", "Whispering")


### PR DESCRIPTION
## Summary
- add weapon materials, modifiers, cores, and effects wordlist templates with sample vocabulary
- demonstrate weighting on the materials template to guide rarity tuning
- extend the objects item README with guidance on reusing the new templates

## Testing
- godot4 --headless --path . --script res://name_generator/tools/dataset_inspector.gd
- godot4 --headless --path . --script res://tests/run_generator_tests.gd
- godot4 --headless --path . --script res://tests/run_diagnostics_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cd996be53c83208a072a1eee30acdb