### PR TITLE
Add template assets for place naming resources

### DIFF
--- a/data/places/markov_models/README.md
+++ b/data/places/markov_models/README.md
@@ -1,0 +1,3 @@
+# Place Markov Models
+
+Placeholder directory for future Markov model `.tres` assets that drive probabilistic place-name generation. Author models here to keep the resource layout aligned with `res://data/places/` expectations.

--- a/data/places/syllable_sets/suffixes_template.tres
+++ b/data/places/syllable_sets/suffixes_template.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("ka", "vel", "aer")
+middles = PackedStringArray("lun", "thar")
+suffixes = PackedStringArray("dos", "thos", "mar")
+allow_empty_middle = true

--- a/data/places/wordlists/biomes/biomes_template.tres
+++ b/data/places/wordlists/biomes/biomes_template.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Marsh", "Archipelago", "Crag", "Verdant Reach")

--- a/data/places/wordlists/descriptors/descriptors_template.tres
+++ b/data/places/wordlists/descriptors/descriptors_template.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("Whispering", "Sunken", "Shattered", "Eldertide")


### PR DESCRIPTION
## Summary
- add starter descriptor and biome wordlist templates for place naming workflows
- provide a syllable set template illustrating prefix, middle, and suffix fragments
- document the markov model directory so future probabilistic assets slot into the expected layout

## Testing
- not run (Godot CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cd9e5978288320abd146d9064e430b