### PR TITLE
Add monster dataset starter assets

### DIFF
--- a/data/markov_models/monsters/cries_template.tres
+++ b/data/markov_models/monsters/cries_template.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("kra", "ghu", "ul", "ith", "rak")
+start_tokens = [{"token": "kra", "weight": 1.0}, {"token": "ghu", "weight": 0.8}]
+transitions = {
+"kra": [{"token": "ghu", "weight": 0.5}, {"token": "rak", "weight": 0.5}],
+"ghu": [{"token": "ul", "weight": 1.0}],
+"ul": [{"token": "ith", "weight": 1.0}],
+"ith": [{"token": "<END>", "weight": 1.0}],
+"rak": [{"token": "ith", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+locale = "guttural"
+domain = "monsters.vocalisations"

--- a/data/markov_models/roots_template.tres
+++ b/data/markov_models/roots_template.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/MarkovModelResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+order = 1
+states = PackedStringArray("har", "bor", "lun", "dra", "mor")
+start_tokens = [{"token": "har", "weight": 1.0}, {"token": "lun", "weight": 0.8}, {"token": "dra", "weight": 0.9}]
+transitions = {
+"har": [{"token": "bor", "weight": 1.0}],
+"bor": [{"token": "<END>", "weight": 0.6}, {"token": "mor", "weight": 0.4}],
+"lun": [{"token": "dra", "weight": 1.0}],
+"dra": [{"token": "<END>", "weight": 0.7}, {"token": "mor", "weight": 0.3}],
+"mor": [{"token": "<END>", "weight": 1.0}]
+}
+end_tokens = PackedStringArray("<END>")
+default_temperature = 1.0
+notes = "Template Markov chain for place-name roots mixing terminal stops and optional suffix jumps."

--- a/data/monsters/behaviours_template.tres
+++ b/data/monsters/behaviours_template.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("stalks the dunes", "guards the nest", "hunts in packs", "lurks in caverns")
+locale = "common"
+domain = "monsters.behaviour"

--- a/data/monsters/body_plans_template.tres
+++ b/data/monsters/body_plans_template.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("quadruped", "serpentine", "carapaced", "avian", "amorphous")
+locale = "common"
+domain = "monsters.anatomy"

--- a/data/monsters/monsREADME.md
+++ b/data/monsters/monsREADME.md
@@ -12,6 +12,12 @@ Provide `WordListResource` assets that catalogue:
 - **Textures and materials** – Skin, scale, fur, and exoskeleton descriptors, including colours and surface qualities.
 - **Anatomical modifiers** – Horn configurations, wing structures, tail types, sensory organs, and elemental infusions.
 
+Starter templates live at:
+
+- [`res://data/monsters/body_plans_template.tres`](body_plans_template.tres)
+- [`res://data/monsters/textures_template.tres`](textures_template.tres)
+- [`res://data/monsters/behaviours_template.tres`](behaviours_template.tres)
+
 Ready-made examples live under `data/monsters/templates/`. Copy the
 `monster_wordlist_template.tres` file to bootstrap a new list with weighting
 metadata already in place.
@@ -20,7 +26,7 @@ Keep each list scoped to a single concept so Hybrid templates can mix and match 
 
 ### Behaviour lexicon
 
-Author complementary `WordListResource` files that describe behaviours, combat styles, and habitats. Break the catalogue into focused themes such as "aggressive openers", "territorial responses", "habitat-specific verbs", and "social patterns". These datasets feed into descriptive suffixes (e.g., "that stalks the dunes") or title prefixes ("The Cradle-Watcher").
+Author complementary `WordListResource` files that describe behaviours, combat styles, and habitats. Break the catalogue into focused themes such as "aggressive openers", "territorial responses", "habitat-specific verbs", and "social patterns". These datasets feed into descriptive suffixes (e.g., "that stalks the dunes") or title prefixes ("The Cradle-Watcher"). Use `behaviours_template.tres` for a quick starting list and expand it into theme-specific catalogues.
 
 ## Creature vocalisation data
 
@@ -33,6 +39,9 @@ Author complementary `WordListResource` files that describe behaviours, combat s
 
 The `monster_syllable_template.tres` example inside `data/monsters/templates/`
 shows a curated prefix/middle/suffix split you can duplicate for new species.
+For neutral guttural calls, load the shared
+[`res://data/syllable_sets/monsters/vocalisations_template.tres`](../syllable_sets/monsters/vocalisations_template.tres)
+resource and replace the syllables with species-specific phonemes.
 
 ### Markov models
 
@@ -43,7 +52,10 @@ shows a curated prefix/middle/suffix split you can duplicate for new species.
 
 For quick experiments, duplicate `monster_markov_template.tres` from
 `data/monsters/templates/`. It already follows the `states`/`start_tokens`
-layout required by the current `MarkovModelResource` implementation.
+layout required by the current `MarkovModelResource` implementation. You can
+also load [`res://data/markov_models/monsters/cries_template.tres`](../markov_models/monsters/cries_template.tres)
+to seed guttural cry patterns for hybrid prototypes before recording bespoke
+datasets.
 
 ## Hybrid strategy examples
 
@@ -56,17 +68,17 @@ var config := {
     "steps": [
         {
             "strategy": "wordlist",
-            "wordlist_paths": ["res://data/monsters/body_plans.tres"],
+            "wordlist_paths": ["res://data/monsters/body_plans_template.tres"],
             "store_as": "body"
         },
         {
             "strategy": "markov",
-            "markov_model_path": "res://data/markov_models/monsters/guttural_calls.tres",
+            "markov_model_path": "res://data/markov_models/monsters/cries_template.tres",
             "store_as": "call"
         },
         {
             "strategy": "syllable",
-            "syllable_set_path": "res://data/syllable_sets/monsters/razor_suffixes.tres",
+            "syllable_set_path": "res://data/syllable_sets/monsters/vocalisations_template.tres",
             "store_as": "suffix"
         }
     ],

--- a/data/monsters/textures_template.tres
+++ b/data/monsters/textures_template.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+entries = PackedStringArray("scaled", "furred", "obsidian-plated", "spore-veiled")
+locale = "common"
+domain = "monsters.anatomy"

--- a/data/places/placesREADME.md
+++ b/data/places/placesREADME.md
@@ -15,13 +15,20 @@ Store datasets as Godot `.tres` resources (or compatible formats) so they load t
 The `data/places/templates/` folder provides example resources that adhere to
 the structure described above:
 
-- `place_wordlist_template.tres` – `WordListResource` with balanced descriptor
-  and biome phrases.
-- `place_syllable_template.tres` – `SyllableSetResource` configured with
-  optional middle fragments to demonstrate compound place roots.
-- `place_markov_template.tres` – `MarkovModelResource` prepared with explicit
-  states, start tokens, and weighted transitions compatible with the current
-  generator runtime.
+- [`place_wordlist_template.tres`](templates/place_wordlist_template.tres) –
+  `WordListResource` with balanced descriptor and biome phrases that you can
+  reference directly as `res://data/places/templates/place_wordlist_template.tres`.
+- [`place_syllable_template.tres`](templates/place_syllable_template.tres) –
+  `SyllableSetResource` configured with optional middle fragments to demonstrate
+  compound place roots (`res://data/places/templates/place_syllable_template.tres`).
+- [`place_markov_template.tres`](templates/place_markov_template.tres) –
+  `MarkovModelResource` prepared with explicit states, start tokens, and weighted
+  transitions compatible with the current generator runtime
+  (`res://data/places/templates/place_markov_template.tres`).
+- [`roots_template.tres`](../markov_models/roots_template.tres) – Markov model
+  stored alongside the shared markov assets. Load it via
+  `res://data/markov_models/roots_template.tres` when you need a neutral root
+  generator for experiments.
 
 Copy and rename a template when you need a quick starting point, then replace
 the placeholder entries with your curated data.
@@ -39,8 +46,8 @@ var config = {
     "strategy": "template",
     "template": "$descriptor $biome",
     "wordlists": {
-        "descriptor": ["res://data/places/wordlists/descriptors/mystic_descriptors.tres"],
-        "biome": ["res://data/places/wordlists/biomes/mountain_biomes.tres"],
+        "descriptor": ["res://data/places/templates/place_wordlist_template.tres"],
+        "biome": ["res://data/places/templates/place_wordlist_template.tres"],
     },
 }
 ```
@@ -58,23 +65,28 @@ var config = {
     "steps": [
         {
             "strategy": "markov",
-            "markov_model_path": "res://data/places/markov_models/coastal_roots.tres",
+            "markov_model_path": "res://data/markov_models/roots_template.tres",
             "store_as": "root",
         },
         {
             "strategy": "syllable",
-            "syllable_set_path": "res://data/places/syllable_sets/shore_suffixes.tres",
+            "syllable_set_path": "res://data/places/templates/place_syllable_template.tres",
             "store_as": "suffix",
         },
         {
             "strategy": "wordlist",
-            "wordlist_paths": ["res://data/places/wordlists/descriptors/nautical_descriptors.tres"],
+            "wordlist_paths": ["res://data/places/templates/place_wordlist_template.tres"],
             "store_as": "descriptor",
         },
     ],
     "template": "$descriptor $root$suffix",
 }
+
 ```
+
+Swap any of the templated paths above with your curated datasets to mix
+bespoke descriptors, syllable suffixes, or trained Markov roots once you're
+ready to graduate from the starter assets.
 
 The hybrid chain lets you blend deterministic syllable assembly with Markov outputs, while the final template preserves control over the final rendering.
 

--- a/data/syllable_sets/monsters/vocalisations_template.tres
+++ b/data/syllable_sets/monsters/vocalisations_template.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/SyllableSetResource.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+prefixes = PackedStringArray("kra", "ghul", "ith", "vor")
+middles = PackedStringArray("gra", "thok", "ruk")
+suffixes = PackedStringArray("nar", "gash", "ith")
+allow_empty_middle = true
+locale = "guttural"
+domain = "monsters.vocalisations"


### PR DESCRIPTION
## Summary
- add reusable place-name Markov roots template that matches the MarkovModelResource schema
- seed monster anatomy, texture, behaviour, syllable, and Markov resources to unblock hybrid bestiary prototyping
- document how to reference the new assets inside the places and monsters dataset guides

## Testing
- `godot --headless --path . --script res://name_generator/tools/dataset_inspector.gd` *(fails: `godot` command not available in container)*
- `godot --headless --script res://tests/run_generator_tests.gd` *(fails: `godot` command not available in container)*
- `godot --headless --script res://tests/run_diagnostics_tests.gd` *(fails: `godot` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cda08d196c8320b130440806a0dab7