### PR TITLE
Add temperate place wordlists

### DIFF
--- a/data/places/placesREADME.md
+++ b/data/places/placesREADME.md
@@ -33,6 +33,16 @@ the structure described above:
 Copy and rename a template when you need a quick starting point, then replace
 the placeholder entries with your curated data.
 
+## Curated wordlists
+
+Use the production-ready lists below to seed temperate biomes without cloning
+the templates when you just need evocative building blocks:
+
+| Resource | Scope | Notes |
+| --- | --- | --- |
+| `wordlists/biomes/temperate_biomes.tres` | Neutral temperate geography nouns (`Vale`, `Moor`, `Wilds`). | Works directly with `$descriptor $biome` templates and Hybrid pipelines that store the biome under an alias for later reuse. |
+| `wordlists/descriptors/temperate_descriptors.tres` | Atmosphere-heavy adjectives (`Whispering`, `Sun-dappled`, `Storm-guarded`). | Pair with the biome list for quick place names or reuse as embellishments in Hybrid templates. |
+
 ## Composing place names
 
 Several generation strategies can reference the datasets in this folder. The examples below mirror the configuration dictionaries passed to `NameGenerator.generate`.

--- a/data/places/wordlists/biomes/temperate_biomes.tres
+++ b/data/places/wordlists/biomes/temperate_biomes.tres
@@ -1,0 +1,33 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray(
+    "Vale",
+    "Forest",
+    "Grove",
+    "Heath",
+    "Moor",
+    "Fen",
+    "Marsh",
+    "Glade",
+    "Highlands",
+    "Lowlands",
+    "Riverlands",
+    "Foothills",
+    "Coast",
+    "Estuary",
+    "Isles",
+    "Wood",
+    "Copse",
+    "Thicket",
+    "Hollows",
+    "Pass",
+    "Ridge",
+    "Valley",
+    "Meadow",
+    "Wilds"
+)
+locale = "en"
+domain = "places:temperate_biomes"

--- a/data/places/wordlists/descriptors/temperate_descriptors.tres
+++ b/data/places/wordlists/descriptors/temperate_descriptors.tres
@@ -1,0 +1,33 @@
+[gd_resource type="Resource" script_class_name="WordListResource" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://name_generator/resources/WordListResource.gd" id="1_0"]
+
+[resource]
+entries = PackedStringArray(
+    "Shrouded",
+    "Whispering",
+    "Silver",
+    "Emerald",
+    "Frost-kissed",
+    "Golden",
+    "Bramble",
+    "Starlit",
+    "Misty",
+    "Verdant",
+    "Ancient",
+    "Autumnal",
+    "Blooming",
+    "Rain-soaked",
+    "Windswept",
+    "Sun-dappled",
+    "Moonlit",
+    "Quiet",
+    "Twilight",
+    "Hidden",
+    "Storm-guarded",
+    "Crystal",
+    "Evergreen",
+    "Shadowed"
+)
+locale = "en"
+domain = "places:temperate_descriptors"


### PR DESCRIPTION
## Summary
- add production temperate biome and descriptor word lists under data/places
- document the new datasets in the places README so authors know when to reuse them

## Testing
- godot4 --headless --path . --script res://name_generator/tools/dataset_inspector.gd
- godot4 --headless --path . --script res://tests/run_platform_gui_tests.gd
- godot4 --headless --path . --script res://tests/run_generator_tests.gd
- godot4 --headless --path . --script res://tests/run_diagnostics_tests.gd

------
https://chatgpt.com/codex/tasks/task_e_68cdb0ac9564832090369f01392e817c